### PR TITLE
Add a better error message when importing an empty save

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1423,6 +1423,10 @@ function resetGameData() {
 function importGameData() {
     try {
         const importExportBox = document.getElementById("importExportBox")
+        if (importExportBox.value == "") {
+            alert("It looks like you tried to load an empty save... Paste save data into the box, then click \"Import Save\" again.")
+            return
+        }
         const data = JSON.parse(window.atob(importExportBox.value))
         clearInterval(gameloop)
         gameData = data


### PR DESCRIPTION
Before this change, importing an empty save would give the same error as importing a corrupt save.

This has been changed; importing an empty save now gives a different error message saying that the imported save data is empty.