### PR TITLE
Use NBSP on "Xp left" to fix a regression in #7

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
                             <th>Level</th>
                             <th class="valueType" style="width: 18em">Value type</th>
                             <th>Xp/day</th>
-                            <th>Xp left</th>
+                            <th>Xp&nbsp;left</th>
                             <th class="maxLevel">Max</th>
                         </tr>
                     </template>


### PR DESCRIPTION
Fixes a regression caused by one of my changes in 1a9dcfcb970a0e8b0319cc6c0653f8de294118ba (#7).

The regression was that when the remaining experience amounts were small enough, the "Xp left" text would have a line break between "Xp" and "left", making that text take up 2 lines and causing the headers to be somewhat taller and take up more space.

Replacing the regular space with a non-breaking space solves this by effectively telling the renderer to treat the whole string "Xp&nbsp;left" as one word.