### PR TITLE
60 FPS update

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -45,7 +45,7 @@ class Task {
 
     increaseXp() {
         if (this.isFinished) {
-            if (Math.random() < 0.001)
+            if (Math.random() < (0.02 / updateSpeed)) // approx 1 level every 50 seconds
                 this.level += 1
             return
         }

--- a/js/main.js
+++ b/js/main.js
@@ -73,7 +73,7 @@ var tempData = {}
 
 var autoBuyEnabled = true
 
-const updateSpeed = 20
+const updateSpeed = 60
 const baseLifespan = 365 * 70
 const baseGameSpeed = 4
 const heroIncomeMult = 2500000000000000000


### PR DESCRIPTION
Game tick speed is raised from 20 FPS to 60 FPS, improving gameplay smoothness. Most computers, including all medium to high end desktops, should be able to run the game at the new tick rate. For example, my i5-9400F CPU with a 3.9 GHz boost clock can run the game at up to 4,000 ticks per second during an `addMinutes()` call from the console.

At endgame, tasks with `isFinished` being true level up on average once every 1,000 ticks. That number now depends on the target game tick speed in order to maintain a 50 second per level average.