### PR TITLE
Increase lifespan precision and better format long time durations

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -437,7 +437,7 @@ function updateHeaderRows(categories) {
 function updateText() {
     //Sidebar
     document.getElementById("ageDisplay").textContent = formatAge(gameData.days)
-    document.getElementById("lifespanDisplay").textContent = format(daysToYears(getLifespan()), 0)
+    document.getElementById("lifespanDisplay").textContent = formatWhole(daysToYears(getLifespan()))
     document.getElementById("realtimeDisplay").textContent = formatTime(gameData.realtime)
     document.getElementById("pauseButton").textContent = gameData.paused ? "Play" : "Pause"
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -33,6 +33,13 @@ function format(number, decimals = 1) {
     }
 }
 
+function formatWhole(number, decimals = 1) {
+    if (number >= 1e3 || (number <= 0.99 && number != 0)) {
+        return format(number, decimals)
+    }
+    return format(number, 0);
+}
+
 function formatCoins(coins, element) {
     const platina = Math.floor(coins / 1e6)
     const gold = Math.floor((coins - platina * 1e6) / 1e4)
@@ -59,9 +66,24 @@ function formatCoins(coins, element) {
     }
 }
 
-function formatTime(sec_num, show_ms=false) {
+function formatTime(sec_num, show_ms = false) {
     if (sec_num == null) {
         return "unknown"
+    }
+    if (sec_num < 0) {
+        return '-' + formatTime(-sec_num, show_ms)
+    }
+    
+    if (sec_num >= 31536000) {
+        let years = Math.floor(sec_num / 31536000)
+        if (years >= 1000) {
+            return formatWhole(years) + ' years'
+        }
+        return years + 'y ' + formatTime(sec_num % 31536000, show_ms)
+    }
+    if (sec_num >= 86400) {
+        let days = Math.floor(sec_num / 86400)
+        return days + 'd ' + formatTime(sec_num % 86400, show_ms)
     }
 
     let hours = Math.floor(sec_num / 3600)


### PR DESCRIPTION
The lifespan display now uses the same precision as the age display to allow better comparisons when getting close to end of lifespan. Previously, the lifespan display used a flat 0 digits after the decimal, causing all values for the lifespan (in years) from 1000-1999 to display as "1k", 2000-2999 as "2k", and so on, and the same for millions (1000000 to 1999999 -> "1M").

Furthermore, all places which display a precise time now use days for durations longer than 24 hours and years for durations longer than 365 days (not that anyone would play this long).

This is most helpful during early-game, full-life runs, and while running challenges.