### PR TITLE
Fix fifth challenge not resetting on game completion

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1410,6 +1410,7 @@ function restartGame() {
     gameData.challenges.rich_and_the_poor = 0
     gameData.challenges.time_does_not_fly = 0
     gameData.challenges.dance_with_the_devil = 0
+    gameData.challenges.legends_never_die = 0
 
     gameData.completedTimes += 1
     saveGameData()


### PR DESCRIPTION
Previously, the fifth challenge would not reset on game completion, causing Evil gain for subsequent runs to be substantially greater.