### PR TITLE
Challenges now have visible goals

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,31 +273,40 @@
 								<div id="anUnhappyLifeChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">1. An unhappy life</div>
 									<div style="color:gray; padding-bottom:0.3em">Reduces happiness by ^0.5</div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <span id="challengeGoal1">992.2M</span> Happiness</div>
 									<div id="challengeReward1" class="reward">Reward: Increases happiness by x<span id="challengeHappinessBuff">1</span></div>
 									<button id="challengeButton1" class="w3-button button" onclick="enterChallenge('an_unhappy_life')">Enter challenge</button>
 								</div>
 								<div id="theRichAndThePoorChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">2. The rich and the poor</div>
 									<div style="color:gray; padding-bottom:0.3em">Reduces income by ^0.35</div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <div id="challengeGoal2" class="coins" style="display:inline">
+										<span></span>
+										<span></span>
+										<span></span>
+										<span></span>
+									</div> Gross Income</div>
 									<div id="challengeReward2" class="reward">Reward: Increases income by x<span id="challengeIncomeBuff">1</span></div>
 									<button id="challengeButton2" class="w3-button button" onclick="enterChallenge('rich_and_the_poor')">Enter challenge</button>
 								</div>
 								<div id="timeDoesNotFlyChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">3. Time does not fly</div>
 									<div style="color: gray; padding-bottom: 0.3em">Reduces time warping by ^0.7</div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach x<span id="challengeGoal3">1.0M</span> Time Warping</div>
 									<div id="challengeReward3" class="reward">Reward: Increases time warping by x<span id="challengeTimewarpingBuff">1</span></div>
 									<button id="challengeButton3" class="w3-button button" onclick="enterChallenge('time_does_not_fly')">Enter challenge</button>
 								</div>
 								<div id="danceWithTheDevilChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">4. Dance with the devil</div>
 									<div style="color: gray; padding-bottom: 0.3em">Reduces Dark Magic and Almightiness XP effect enormously, max level reduces XP gain and happiness is reduced by ^0.075</div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <span id="challengeGoal4">5.8k</span> Evil Gain</div>
 									<div id="challengeReward4" class="reward">Reward: Increases essence gain by x<span id="challengeEssenceGainBuff">1</span></div>
 									<button id="challengeButton4" class="w3-button button" onclick="enterChallenge('dance_with_the_devil')">Enter challenge</button>
 								</div>
 								<div id="legendsNeverDieChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">5. Legends never die</div>
 									<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, happiness does nothing and Dark Magic XP effect is always 1x</div>
-									<div style="color: gray; padding-bottom: 0.3em">Goal: Reach the Chairman</div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach Chairman lvl <span id="challengeGoal5">1227</span></div>
 									<div id="challengeReward5" class="reward">Reward: Increases evil gain by x<span id="challengeEvilGainBuff">1</span></div>
 									<button id="challengeButton5" class="w3-button button" onclick="enterChallenge('legends_never_die')">Enter challenge</button>
 								</div>

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -27,7 +27,7 @@ function setChallengeProgress() {
         gameData.challenges.rich_and_the_poor = Math.max(gameData.challenges.rich_and_the_poor, getIncome())
     }
     if (gameData.active_challenge == "time_does_not_fly") {
-        gameData.challenges.time_does_not_fly = Math.max(gameData.challenges.time_does_not_fly, getGameSpeed())
+        gameData.challenges.time_does_not_fly = Math.max(gameData.challenges.time_does_not_fly, getUnpausedGameSpeed() / baseGameSpeed)
     }
     if (gameData.active_challenge == "dance_with_the_devil") {
         gameData.challenges.dance_with_the_devil = Math.max(gameData.challenges.dance_with_the_devil, Math.max(0, getEvilGain() - 10))
@@ -45,7 +45,7 @@ function getChallengeBonus(challenge_name, current = false) {
         return softcap(Math.pow((current ? getIncome() : gameData.challenges.rich_and_the_poor) + 1, 0.25), 25, 0.55)
     }
     if (challenge_name == "time_does_not_fly") {
-        return softcap(Math.pow((current ? getGameSpeed() : gameData.challenges.time_does_not_fly) + 1, 0.05), 2)
+        return softcap(Math.pow((current ? getUnpausedGameSpeed() / baseGameSpeed : gameData.challenges.time_does_not_fly) + 1, 0.05), 2)
     }
     if (challenge_name == "dance_with_the_devil") {
         return softcap(Math.pow((current ? Math.max(0, getEvilGain() - 10) : gameData.challenges.dance_with_the_devil) + 1, 0.09), 2, 0.75)
@@ -55,3 +55,20 @@ function getChallengeBonus(challenge_name, current = false) {
     }
 }
 
+function getChallengeGoal(challenge_name) {
+    if (challenge_name == "an_unhappy_life") {
+        return gameData.challenges.an_unhappy_life + 1
+    }
+    if (challenge_name == "rich_and_the_poor") {
+        return gameData.challenges.rich_and_the_poor + 1
+    }
+    if (challenge_name == "time_does_not_fly") {
+        return Math.max(1, gameData.challenges.time_does_not_fly + 0.1)
+    }
+    if (challenge_name == "dance_with_the_devil") {
+        return gameData.challenges.dance_with_the_devil + 10.1
+    }
+    if (challenge_name == "legends_never_die") {
+        return gameData.challenges.legends_never_die + 1
+    }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -894,13 +894,21 @@ function getDarkOrbs() {
 }
 
 function getGameSpeed() {
+    if (!canSimulate())
+        return 0
+    
+    return getUnpausedGameSpeed()
+}
+
+function getUnpausedGameSpeed() {
     const timeWarping = gameData.taskData["Time Warping"]
-	const temporalDimension = gameData.taskData["Temporal Dimension"]
+    const temporalDimension = gameData.taskData["Temporal Dimension"]
     const timeLoop = gameData.taskData["Time Loop"]
     const warpDrive = (gameData.requirements["Eternal Time"].isCompleted()) ? 2 : 1
     const timeWarpingSpeed = timeWarping.getEffect() * temporalDimension.getEffect() * timeLoop.getEffect() * warpDrive
     const speedIsLife = gameData.dark_matter_shop.speed_is_life == 1 ? 3 : (gameData.dark_matter_shop.speed_is_life == 2 ? 7 : 1)
-    const gameSpeed = baseGameSpeed * +!gameData.paused * +isAlive() * timeWarpingSpeed * getChallengeBonus("time_does_not_fly") * speedIsLife
+    const gameSpeed = baseGameSpeed * timeWarpingSpeed * getChallengeBonus("time_does_not_fly") * speedIsLife
+    
     return gameData.active_challenge == "time_does_not_fly" ? Math.pow(gameSpeed, 0.7) : gameSpeed
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -491,9 +491,7 @@ function updateText() {
         getChallengeBonus("time_does_not_fly")
         * (gameData.dark_matter_shop.speed_is_life == 1 ? 3 : (gameData.dark_matter_shop.speed_is_life == 2 ? 7 : 1))
 
-    document.getElementById("timeWarpingDisplay").textContent = "x" + format(
-        gameData.active_challenge == "time_does_not_fly" ? Math.pow(timeWarping, 0.7) : timeWarping
-    )
+    document.getElementById("timeWarpingDisplay").textContent = "x" + format(getUnpausedGameSpeed() / baseGameSpeed)
 
     // Transcend for Next Milestone indicator
     const button = document.getElementById("rebirthButton3").getElementsByClassName("button")[0]
@@ -590,6 +588,12 @@ function updateText() {
             }
         }
     }
+    
+    document.getElementById("challengeGoal1").textContent = format(getChallengeGoal("an_unhappy_life"))
+    formatCoins(getChallengeGoal("rich_and_the_poor"), document.getElementById("challengeGoal2"))
+    document.getElementById("challengeGoal3").textContent = format(getChallengeGoal("time_does_not_fly"))
+    document.getElementById("challengeGoal4").textContent = format(getChallengeGoal("dance_with_the_devil"))
+    document.getElementById("challengeGoal5").textContent = Math.floor(getChallengeGoal("legends_never_die"))
 
     document.getElementById("challengeReward1").hidden = gameData.challenges.an_unhappy_life == 0
     document.getElementById("challengeReward2").hidden = gameData.challenges.rich_and_the_poor == 0


### PR DESCRIPTION
Each challenge now displays its goal, which is the minimum required amount of the challenge stat (happiness, income, and game speed respectively for the first 3 challenges) that will allow completing the challenge to increase the reward.

Furthermore, a display error in Time Warping has been fixed (reproducible while running the 3rd challenge).