### PR TITLE
More coin currencies and new currency notations

### DIFF
--- a/css/currencies.css
+++ b/css/currencies.css
@@ -1,18 +1,24 @@
 @keyframes currency-rainbow{
     0% {
-        color: red;
+        color: #FF4040;
     }
-    25% {
-        color: yellow;
+    16% {
+        color: #FFFF40;
+    }
+    33% {
+        color: #40FF40;
     }
     50% {
-        color: lime;
+        color: #40FFFF;
     }
-    75% {
-        color: #0080ff;
+    66% {
+        color: #4040FF;
+    }
+    83% {
+        color: #FF40FF;
     }
     100% {
-        color: magenta;
+        color: #FF4040;
     }
 }
 
@@ -28,5 +34,5 @@
 .currency-shadow-rainbow{
     font-weight: bold;
     text-shadow: 0 0 5px currentColor;
-    animation: currency-rainbow 6s infinite;
+    animation: currency-rainbow 12s infinite;
 }

--- a/css/currencies.css
+++ b/css/currencies.css
@@ -1,0 +1,32 @@
+@keyframes currency-rainbow{
+    0% {
+        color: red;
+    }
+    25% {
+        color: yellow;
+    }
+    50% {
+        color: lime;
+    }
+    75% {
+        color: #0080ff;
+    }
+    100% {
+        color: magenta;
+    }
+}
+
+.currency-bold{
+    font-weight: bold;
+}
+
+.currency-shadow{
+    font-weight: bold;
+    text-shadow: 0 0 5px currentColor;
+}
+
+.currency-shadow-rainbow{
+    font-weight: bold;
+    text-shadow: 0 0 5px currentColor;
+    animation: currency-rainbow 6s infinite;
+}

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                                  </button>
                             </th>
                             <th>Active</th>
-                            <th style="width: 22em">Effect</th>
+                            <th style="width: 20em">Effect</th>
                             <th>Expense/day</th>
                         </tr>                        
                     </template>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" type="text/css" href="css/styles.css">
     <link rel="stylesheet" type="text/css" href="css/dark.css">
     <link rel="stylesheet" type="text/css" href="css/colorblind.css">
+    <link rel="stylesheet" type="text/css" href="css/currencies.css">
     <title>Progress Knight Quest</title>
     <link rel="shortcut icon" href="img/logo.ico" />
 </head>
@@ -448,7 +449,16 @@
                                                         <td><input id="settingsStickySidebar" type="checkbox" style="width:1.6em;height:1.6em" onclick="setStickySidebar(this.checked)" /></td>
                                                     </tr>
                                                     <tr>
-                                                        <td>Numbers notation</td>
+                                                        <td>Currency notation</td>
+                                                        <td style="padding: 0.4em">
+                                                            <button class="w3-button button CurrencyNotation selected" onclick="setCurrency(0)">Medieval</button>
+                                                            <button class="w3-button button CurrencyNotation" onclick="setCurrency(1)">Extended</button>
+                                                            <button class="w3-button button CurrencyNotation" onclick="setCurrency(2)">British £sd</button>
+                                                            <button class="w3-button button CurrencyNotation" onclick="setCurrency(3)">Modern $</button>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>Number notation</td>
                                                         <td style="padding: 0.4em">
                                                             <button class="w3-button button Notation selected" onclick="setNotation(0)">Standard</button>
                                                             <button class="w3-button button Notation" onclick="setNotation(1)">Scientific</button>

--- a/js/main.js
+++ b/js/main.js
@@ -28,6 +28,7 @@ var gameData = {
     settings: {
         stickySidebar: true,
         theme: 1,
+        currencyNotation: 0,
         numberNotation: 0,
         layout: 1,
         fontSize: 3,
@@ -884,6 +885,11 @@ function createGameObject(data, entity) {
     else if ("tier" in entity) { data[entity.name] = new Milestone(entity) }    
     else {data[entity.name] = new Item(entity)}
     data[entity.name].id = "row " + entity.name
+}
+
+function setCurrency(index) {
+    gameData.settings.currencyNotation = index
+    selectElementInGroup("CurrencyNotation", index)
 }
 
 function setNotation(index) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,6 +2,7 @@ function initUI() {
     setLayout(gameData.settings.layout)
     setFontSize(gameData.settings.fontSize)
     setNotation(gameData.settings.numberNotation)
+    setCurrency(gameData.settings.currencyNotation)
     setStickySidebar(gameData.settings.stickySidebar)
 
     setTheme(gameData.settings.theme)

--- a/js/utils.js
+++ b/js/utils.js
@@ -33,29 +33,75 @@ function format(number, decimals = 1) {
     }
 }
 
-function formatCoins(coins, element) {
-    const platina = Math.floor(coins / 1e6)
-    const gold = Math.floor((coins - platina * 1e6) / 1e4)
-    const silver = Math.floor((coins - platina * 1e6 - gold * 1e4) / 100)
-    const copper = Math.floor(coins - platina * 1e6 - gold * 1e4 - silver * 100)
-
-    const money = {
-        "p": { "color": "#79b9c7", "showbefore": null, "value": platina },
-        "g": { "color": "#E5C100", "showbefore": 1e8, "value": gold },
-        "s": { "color": "#a8a8a8", "showbefore": 1e6, "value": silver },
-        "c": { "color": "#a15c2f", "showbefore": 1e4, "value": copper },
+function getCoinsData() {
+    switch (gameData.settings.currencyNotation) {
+        case 0: return [
+            { "name": "p", "color": "#79b9c7", "value": 1e6 },
+            { "name": "g", "color": "#E5C100", "value": 10000 },
+            { "name": "s", "color": "#a8a8a8", "value": 100 },
+            { "name": "c", "color": "#a15c2f", "value": 1 },
+        ];
+        case 1: return [
+            { "name": " 𒀱", "color": "#ffffff", "value": 1e62, "class": "currency-shadow-rainbow" },
+            { "name": " 𒀱", "color": "#ffffff", "value": 1e47, "class": "currency-shadow" },
+            { "name": " 𒇫", "color": "#66ccff", "value": 1e41, "class": "currency-shadow" },
+            { "name": "🜊", "color": "#00ff00", "value": 1e35, "class": "currency-bold" },
+            { "name": "✹", "color": "#ffffcc", "value": 1e30 },
+            { "name": "∰", "color": "#ff0083", "value": 1e26 },
+            { "name": "Φ", "color": "#27b897", "value": 1e23 },
+            { "name": "Ξ", "color": "#cd72ff", "value": 1e20 },
+            { "name": "Δ", "color": "#f5c211", "value": 1e17 },
+            { "name": "d", "color": "#ffffff", "value": 1e14 },
+            { "name": "r", "color": "#ed333b", "value": 1e12 },
+            { "name": "S", "color": "#6666ff", "value": 1e10 },
+            { "name": "e", "color": "#2ec27e", "value": 1e8 },
+            { "name": "p", "color": "#79b9c7", "value": 1e6 },
+            { "name": "g", "color": "#E5C100", "value": 10000 },
+            { "name": "s", "color": "#a8a8a8", "value": 100 },
+            { "name": "c", "color": "#a15c2f", "value": 1 },
+        ];
+        case 2: return [
+            { "name": "", "color": "#E5C100", "value": 240, "prefix": "£" },
+            { "name": "s", "color": "#a8a8a8", "value": 12 },
+            { "name": "d", "color": "#a15c2f", "value": 1 },
+        ];
+        default: throw new Error("Invalid currency notation set");
     }
+}
 
-    let i = 0
-    for (const key in money) {
-        if ((money[key].showbefore == null || coins < money[key].showbefore) && (money[key].value > 0 || money[key].value == 0 && key == "c" && coins >= 0)) {
-            element.children[i].textContent = format(money[key].value, money[key].value < 1000 ? 0 : 1) + key
-            element.children[i].style.color = money[key].color
-        }
-        else {
-            element.children[i].textContent = ""            
-        }
-        i++
+function formatCoins(coins, element) {
+    for (const c of element.children) {
+        c.textContent = "";
+    }
+    
+    switch (gameData.settings.currencyNotation) {
+        case 0:
+        case 1:
+        case 2:
+            const money2 = getCoinsData()
+            
+            let coinsUsed = 0
+            for (let i = 0; i < money2.length; i++) {
+                const m = money2[i];
+                const prev = money2[i - 1];
+                const diff = prev ? prev.value / m.value : Infinity;
+                const amount = Math.floor(coins / m.value) % diff;
+                if ((amount > 0 || (coins < 1 && m.value == 1))) {
+                    element.children[coinsUsed].textContent = (m.prefix ?? "") + format(amount, amount < 1000 ? 0 : 2) + m.name
+                    element.children[coinsUsed].style.color = m.color
+                    element.children[coinsUsed].className = m.class ? m.class : ""
+                    coinsUsed++
+                }
+                if (coinsUsed >= 2 || amount >= 100) break;
+            }
+            break;
+        case 3:
+            element.children[0].textContent = "$" + format(coins / 100, 2)
+            element.children[0].style.color = "#E5C100"
+            element.children[0].className = ""
+            break;
+        default:
+            throw new Error("Invalid currency notation set");
     }
 }
 


### PR DESCRIPTION
Multiple new currency options are added, along with a setting to go with them.

* Medieval: The original coin currencies in Progress Knight and the default set for this mod.
* Extended: Adds many new coin currencies with increasing values. The currencies are from a set originally curated by @veprogames for their mod.
* British: The old £sd system used in England until the mid-20th century.
* Modern: Currency used in the modern world, with an old silver coin now worth one dollar.

Note: I was unable to render the following characters in the "Extended" currency set on my system; they have been replaced. Feel free to suggest better alternatives if you want.
* 𐅍 U+1014D "GREEK ACROPHONIC ATTIC ONE THOUSAND TALENTS" with value 1e20 has been replaced with Ξ.
* 𐙋 U+1064B "LINEAR A SIGN AB122" with value 1e23 has been replaced with Φ.
* ⯚ U+2BDA "HYGIEA" with value 1e35 has been replaced with `🜊` (looks like a cross symbol).