### PR TITLE
Add total game time elapsed

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,7 +614,8 @@
 											<div>
 												<ul>
 													<li>You started playing the game on <span id="startDateDisplay"></span>.</li>
-													<li>You have played for <span id="playedDaysDisplay"></span> days.</li>
+													<li>You have played for <span id="playedDaysDisplay"></span> days (real time).</li>
+													<li>Your existance has spanned <span id="playedGameTimeDisplay"></span> days (game time).</li>
 												</ul>
 											</div>
 											<div id="statsRebirth1" class="hidden">

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,7 @@ var gameData = {
 
     coins: 0,
     days: 365 * 14,
+    totalDays: 0,
     evil: 0,
     essence: 0,
     dark_matter: 0,
@@ -1086,6 +1087,7 @@ function autoBuy() {
 
 function increaseDays() {
     gameData.days += applySpeed(1)
+    gameData.totalDays += applySpeed(1)
 }
 
 function increaseRealtime() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -506,6 +506,8 @@ function updateText() {
     const currentDate = new Date()
     document.getElementById("playedDaysDisplay").textContent = format((currentDate.getTime() - date.getTime()) / (1000 * 3600 * 24), 2)
 
+    document.getElementById("playedGameTimeDisplay").textContent = format(gameData.totalDays, 2)
+
     if (gameData.rebirthOneCount > 0)
         document.getElementById("statsRebirth1").classList.remove("hidden")
     else


### PR DESCRIPTION
Added text displaying the total amount of game time elapsed since first start or hard reset.
Like the real time played indicator, the total game time counter does not reset on any form of prestige.