### PR TITLE
Fix some grammar in new Dark Matter content

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 					</div>
 					<div id="deathText" class="hidden">
 						<div class="text-caption" style="color: red">Age has caught up to you</div>
-						<div class="sidebar-element" style="color: gray">Your age has met your lifespan, use the amulet to rebirth before you pass away</div>
+						<div class="sidebar-element" style="color: gray">Your age has met your lifespan; use the amulet to rebirth before you pass away</div>
 					</div>
 					<div class="text-caption"><span id="ageDisplay">Age 14 Day 0</span></div>
 					<div class="sidebar-element" style="color: gray">
@@ -460,7 +460,7 @@
 										<div class="panel w3-margin-left w3-margin-top w3-padding">
 											<div style="padding-top:2em">
 												<div style="color:gray; padding-bottom:0.3em">
-													You have to choose 1 upgrade in each category, pick wisely. You can reset the skills, but you will <b>NOT</b> get your <span style="color: rgb(114, 83, 182)">Dark Matter</span> back!
+													You can only choose 1 upgrade in each category; pick wisely. You can reset the skills, but you will <b>NOT</b> get your <span style="color: rgb(114, 83, 182)">Dark Matter</span> back!
 												</div>
 												<button class="w3-button button" onclick="resetSkillTree()">Reset Skills</button>
 											</div>
@@ -468,14 +468,14 @@
 												<div class="text-caption dark-matter-title">Speed is life</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="speedIsLife1" class="w3-button button" onclick="buySpeedOfLife(1)">Buy</button> - 
-													Increase <span style="color: rgb(204, 34, 219)">Time Warping</span> by <b>3x</b>, 
-													but decrease <span style="color: rgb(200, 0, 0)">Evil</span> gain by <b>2x</b>
+													Multiply <span style="color: rgb(204, 34, 219)">Time Warping</span> by <b>3x</b>, 
+													but divide <span style="color: rgb(200, 0, 0)">Evil</span> gain by <b>2x</b>
 												</div>
 												<div style="color: rgb(255, 255, 255); padding: 0.6em">OR</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="speedIsLife2" class="w3-button button" onclick="buySpeedOfLife(2)">Buy</button> - 
-													Increase <span style="color: rgb(204, 34, 219)">Time Warping</span> by <b>7x</b>, 
-													but decrease <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>2x</b>
+													Multiply <span style="color: rgb(204, 34, 219)">Time Warping</span> by <b>7x</b>, 
+													but divide <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>2x</b>
 												</div>
 												<div style="color:gray; padding-bottom: 0.5em;">Cost: <b>100</b> <span style="color: rgb(114, 83, 182)">Dark Matter</span></div>
 											</div>
@@ -483,14 +483,14 @@
 												<div class="text-caption dark-matter-title">Your greatest debt</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="yourGreatestDebt1" class="w3-button button" onclick="buyYourGreatestDebt(1)">Buy</button> - 
-													Increase <span style="color:rgb(255, 204, 102)">all XP</span> gain by <b>500x</b>, 
-													but decrease <span style="color: lightgreen;">Income</span> by <b>1000x</b>
+													Multiply <span style="color:rgb(255, 204, 102)">all XP</span> gain by <b>500x</b>, 
+													but divide <span style="color: lightgreen;">Income</span> by <b>1000x</b>
 												</div>
 												<div style="color: rgb(255, 255, 255); padding: 0.6em">OR</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="yourGreatestDebt2" class="w3-button button" onclick="buyYourGreatestDebt(2)">Buy</button> - 
-													Increase <span style="color: rgb(200, 0, 0)">Evil gain</span> by <b>100x</b>, 
-													but decrease <span style="color: lightgreen;">Income</span> by <b>250x</b>
+													Multiply <span style="color: rgb(200, 0, 0)">Evil gain</span> by <b>100x</b>, 
+													but divide <span style="color: lightgreen;">Income</span> by <b>250x</b>
 												</div>
 												<div style="color:gray; padding-bottom: 0.5em;">Cost: <b>1k</b> <span style="color: rgb(114, 83, 182)">Dark Matter</span></div>
 											</div>
@@ -498,14 +498,14 @@
 												<div class="text-caption dark-matter-title">Essence collector</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="essenceCollector1" class="w3-button button" onclick="buyEssenceCollector(1)">Buy</button> - 
-													Increase <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>500x</b>, 
-													but decrease <span style="color: rgb(200, 0, 0)">Evil</span> gain by <b>2x</b>
+													Multiply <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>500x</b>, 
+													but divide <span style="color: rgb(200, 0, 0)">Evil</span> gain by <b>2x</b>
 												</div>
 												<div style="color: rgb(255, 255, 255); padding: 0.6em">OR</div>
 												<div style="color:gray; padding-bottom:0.3em">
 													<button id="essenceCollector2" class="w3-button button" onclick="buyEssenceCollector(2)">Buy</button> - 
-													Increase <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>1000x</b>, 
-													but decrease <span style="color: lightgreen;">Income</span> by <b>50x</b>
+													Multiply <span style="color: rgb(24, 210, 217)">Essence</span> gain by <b>1000x</b>, 
+													but divide <span style="color: lightgreen;">Income</span> by <b>50x</b>
 												</div>
 												<div style="color:gray; padding-bottom: 0.5em;">Cost: <b>10k</b> <span style="color: rgb(114, 83, 182)">Dark Matter</span></div>
 											</div>

--- a/js/main.js
+++ b/js/main.js
@@ -463,10 +463,10 @@ const tooltips = {
     // Darkness
     "Dark Prince": "You can increase your intelligence at an alarming rate due to your access to all libraries in the universe.",
     "Dark Ruler": "Ruling the universe allows you to collect more Dark Matter from your subordinates.",
-    "Immortal Ruler": "You have only one goal. Ruling this universe till infinity.",
+    "Immortal Ruler": "You have only one goal: ruling this universe till infinity.",
     "Dark Magician": "By performing forbidden magic on your subordinates, you can extract every last drop of Essence from them.",
     "Universal Ruler": "No one dares to challenge your rule when ruling with an iron fist.",
-    "Blinded By Darkness": "Blinded by darkness you can no longer control yourself. You start to destroy everything in existance to calm yourself.",
+    "Blinded By Darkness": "Blinded by darkness, you can no longer control yourself. You start to destroy everything in existance to calm yourself.",
 	
     //Properties
     "Homeless": "Sleep on the uncomfortable, filthy streets while almost freezing to death every night. It cannot get any worse than this.",


### PR DESCRIPTION
The new "Dark Matter Skills" upgrades had generic "Increases" and "Decreases" effects, but the actual effect is that it multiplies or divides a certain value (such as evil or essence gain). I've fixed the descriptions to reflect this.

There was some incorrect punctuation in some of the new strings added in the same update; the punctuation is now fixed.