### PR TITLE
Limit Dark Orb Generators

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@
 													<div class="text-caption dark-matter-title">Dark Orb Generator</div>
 													<div style="color:gray; padding-bottom:0.3em">Generates <b id="darkOrbGenerator"></b> <span style="color: rgb(143, 114, 207)">Dark Orb</span> per day</div>
 													<div style="color:gray; padding-bottom: 0.5em;">Cost: <b id="darkOrbGeneratorCost"></b> <span style="color: rgb(114, 83, 182)">Dark Matter</span></div>
-													<button class="w3-button button" onclick="buyDarkOrbGenerator()">Upgrade</button>
+													<button class="w3-button button" id="darkOrbGeneratorBuyButton" onclick="buyDarkOrbGenerator()">Upgrade</button>
 												</div>
 												<div style="padding-top:2em">
 													<div class="text-caption dark-matter-title">A miracle</div>

--- a/js/dark_matter.js
+++ b/js/dark_matter.js
@@ -4,7 +4,7 @@ function getDarkOrbGeneratorCost() {
 }
 
 function buyDarkOrbGenerator() {
-    if (gameData.dark_matter >= getDarkOrbGeneratorCost()) {
+    if (gameData.dark_matter >= getDarkOrbGeneratorCost() && getDarkOrbGeneration() != Infinity) {
         gameData.dark_matter -= getDarkOrbGeneratorCost()
         gameData.dark_matter_shop.dark_orb_generator += 1
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -507,6 +507,11 @@ function renderDarkMatter() {
 
     if (gameData.dark_matter_shop.a_miracle)
         document.getElementById("aMiracleBuyButton").classList.add("hidden")
+    
+    if (getDarkOrbGeneration() != Infinity)
+        document.getElementById("darkOrbGeneratorBuyButton").classList.remove("hidden")
+    else
+        document.getElementById("darkOrbGeneratorBuyButton").classList.add("hidden")
 
     // Dark Matter Skill tree
     renderSkillTreeButton(document.getElementById("speedIsLife1"), gameData.dark_matter_shop.speed_is_life != 0, gameData.dark_matter_shop.speed_is_life == 1)


### PR DESCRIPTION
Limit the total number of purchased Dark Orb Generators to prevent unnecessarily spending valuable Dark Matter on something that's of no use past a certain point.

The limit triggers when the daily generation of Dark Matter goes infinite; therefore, the exact limit may vary depending on whether a certain Essence milestone is active.