### PR TITLE
Add missing commas to corrupted save error messages

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1466,7 +1466,7 @@ function peekThemeFromSave() {
     } catch (error) {
         console.error(error)
         console.log(localStorage.getItem("gameDataSave"))
-        alert("It looks like you tried to load a corrupted save... If this issue persists feel free to contact the developers!")
+        alert("It looks like you tried to load a corrupted save... If this issue persists, feel free to contact the developers!")
     }
 }
 
@@ -1482,7 +1482,7 @@ function peekFontSizeFromSave() {
     } catch (error) {
         console.error(error)
         console.log(localStorage.getItem("gameDataSave"))
-        alert("It looks like you tried to load a corrupted save... If this issue persists feel free to contact the developers!")
+        alert("It looks like you tried to load a corrupted save... If this issue persists, feel free to contact the developers!")
     }
 }
 


### PR DESCRIPTION
The "corrupted save" error message was missing a comma in two occurrences; that is now fixed, making the punctuation consistent with other occurrences of the same message.