### PR TITLE
Fix the possibility of Dark Orbs being set to NaN

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -837,6 +837,8 @@ function applyMultipliers(value, multipliers) {
 function applySpeed(value) {
     if (value == 0)
         return 0
+    if (value == Infinity)
+        return Infinity
     return value * getGameSpeed() / updateSpeed
 }
 
@@ -1523,7 +1525,7 @@ function loadGameData() {
             if (gameData.dark_matter == null || isNaN(gameData.dark_matter))
                 gameData.dark_matter = 0
 
-            if (gameData.dark_orbs == null || isNaN(gameData.dark_matter))
+            if (gameData.dark_orbs == null || isNaN(gameData.dark_matter) || isNaN(gameData.dark_orbs))
                 gameData.dark_orbs = 0
 
             if (gameData.settings.theme == null) {


### PR DESCRIPTION
Once Dark Orbs (or any other number) went infinite, the next time the game was paused for any reason, that number would be set to NaN, as the current game speed of 0, times the daily production of Infinity, equals NaN, which, when added to any other number, equals NaN.

This is now fixed: if Dark Orbs per day is infinite, then Dark Orbs is also always infinite.

Furthermore, this bug may have already been triggered at least once by somebody, causing their save's Dark Orbs value to be NaN. A check has been added that will set Dark Orbs to 0 on load if that's the case.