### PR TITLE
Add 5 new shop items between Planet and The Universe

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,6 +691,7 @@
 		<script type="text/javascript" src="js/classes.js"></script>
 		<script type="text/javascript" src="js/challenges.js"></script>
 		<script type="text/javascript" src="js/dark_matter.js"></script>
+		<script type="text/javascript" src="js/tooltips.js"></script>
 		<script type="text/javascript" src="js/main.js"></script>
 	</body>
 </html>

--- a/js/classes.js
+++ b/js/classes.js
@@ -215,8 +215,10 @@ class Item {
         return "x" + format(effect) + " " + description
     }
 
-    getExpense() {
-        return (this.isHero ? 4 * Math.pow(10, this.baseData.heromult) * heroIncomeMult : 1) 
+    getExpense(heroic) {
+        if (heroic === undefined)
+            heroic = this.isHero
+        return (heroic ? 4 * Math.pow(10, this.baseData.heromult) * heroIncomeMult : 1) 
             * applyMultipliers(this.baseData.expense, this.expenseMultipliers) 
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -133,7 +133,6 @@ const jobBaseData = {
     "Sigma Proioxis": { name: "Sigma Proioxis", maxXp: 500000000000000000000, income: 25000000000000, heroxp: 260 },
     "Acallaris": { name: "Acallaris", maxXp: 50000000000000000000000, income: 215000000000000, heroxp: 263 },
     "One Above All": { name: "One Above All", maxXp: 5000000000000000000000000000, income: 25000000000000000, heroxp: 265 },
-
 }
 
 const skillBaseData = {
@@ -211,7 +210,6 @@ const itemBaseData = {
     "Spaceship": { name: "Spaceship", expense: 1000000000000000000, effect: 1500000, heromult: 15, heroeffect: 5e42 },
     "Planet": { name: "Planet", expense: 1e22, effect: 5000000, heromult: 16, heroeffect: 5e46 },
     "The Universe": { name: "The Universe", expense: 1e24, effect: 50000000, heromult: 17, heroeffect: 5e49 },
-
 
     "Book": { name: "Book", expense: 10, effect: 1.5, description: "Ability XP", heromult: 2 },
     "Dumbbells": { name: "Dumbbells", expense: 50, effect: 1.5, description: "Strength XP", heromult: 2 },
@@ -362,190 +360,6 @@ const headerRowTextColors = {
     "Essence Milestones": "purple",
     "Heroic Milestones": "purple",
     "Dark Milestones": "purple",
-}
-
-const tooltips = {
-	// Common work
-    "Beggar": "Struggle day and night for a couple of copper coins. It feels like you are at the brink of death each day.",
-    "Farmer": "Plow the fields and grow the crops. It's not much but it's honest work.",
-    "Fisherman": "Reel in various fish and sell them for a handful of coins. A relaxing but still poor paying job.",
-    "Miner": "Delve into dangerous caverns and mine valuable ores. The pay is quite meager compared to the risk involved.",
-    "Blacksmith": "Smelt ores and carefully forge weapons for the military. A respectable and OK paying commoner job.",
-    "Merchant": "Travel from town to town, bartering fine goods. The job pays decently well and is a lot less manually-intensive.",
-
-    // Military
-    "Squire": "Carry around your knight's shield and sword along the battlefield. Very meager pay but the work experience is quite valuable.",
-    "Footman": "Put down your life to battle with enemy soldiers. A courageous, respectable job but you are still worthless in the grand scheme of things.",
-    "Veteran footman": "More experienced and useful than the average footman, take out the enemy forces in battle with your might. The pay is not that bad.",
-    "Centenary": "By proving your skills with a bow, you were appointed to lead a small group of archers to ambush your enemies from a distance.",
-    "Knight": "Slash and pierce through enemy soldiers with ease, while covered in steel from head to toe. A decently paying and very respectable job.",
-    "Veteran Knight": "Utilising your unmatched combat ability, slaugher enemies effortlessly. Most footmen in the military would never be able to acquire such a well paying job like this.",
-    "Holy Knight": "Obliterate squadrons of enemy soldiers in one go with extraordinary proficiency, while wielding a magically imbued blade. Such a feared unit on the battlefield is paid extremely well.",
-    "Lieutenant General": "Feared by nations, obliterate entire armies in a blink of an eye. Roughly every century, only one holy knight is worthy of receiving such an esteemed title.",
-
-    // The Arcane Association
-    "Student": "Study the theory of mana and practice basic spells. There is minor pay to cover living costs; however, this is a necessary stage in becoming a mage.",
-    "Apprentice Mage": "Under the supervision of a skilled mage, perform basic spells against enemies in battle. Generous pay will be provided to cover living costs.",
-    "Adept Mage": "Turn the tides of battle through casting intermediate spells and mentor other apprentices. The pay for this particular job is extremely high.",
-    "Master Wizard": "Utilise advanced spells to ravage and destroy entire legions of enemy soldiers. Only a small percentage of mages deserve to attain this role and are rewarded with an insanely high pay.",
-    "Archmage": "Blessed with unparalleled talent, perform unbelievable feats with magic at will. It is said that an archmage has enough destructive power to wipe an empire off the map.",
-	"Chronomancer": "Specialize in harnessing temporal energies that alter the flow of time with supernatural divinations and otherwordly expertise.",
-    "Chairman": "Spend your days administrating The Arcane Association and investigate the concepts of true immortality. The chairman receives ludicrous amounts of pay daily.",
-	"Imperator": "You wield an unlimited power, making you unstoppable. By ruling with an iron fist, everyone in the Arcane Association has to obey your commands.",
-
-    // The Void
-    "Corrupted": "Corrupted by Void, you are slowly turning into a slave with no free will, just to serve the Void for the rest of eternity... Can you resist it, or will it consume you forever?",
-    "Void Slave": "Each day, you are succumbing to the Void more and more. Can you hold onto your humanity for a bit longer, or will you let the Void devour you?",
-    "Void Fiend": "You become an inquisitive yet putrid creature that siphons life from everything around you.",
-	"Abyss Anomaly": "Screaming into existence, you become a manifestation of the unknowable nothingness that lies beyond.",
-	"Void Wraith": "Damned soul... a shadow of your former self, lingering between realms and consumed by void... Can you ever find peace?",
-	"Void Reaver": "There are few who may tread the paths between worlds, these powers grant you an ability to generate fields of void energy that devour all living things.",
-	"Void Lord": "You gazed into the dark heart of the Void long enough to become one of the most powerful and feared beings. All lesser void creatures are at your command.",
-	"Abyss God": "Creator of the Void, a vast canvas of blackness and nothingness, in which the concept of its existence defies all logic. Nothing will escape you.",
-
-    // Galactic Council
-    "Eternal Wanderer": "With the powers bestowed upon you by an unknown entity, you wander around, visiting places revered and feared in search of answers.",
-    "Nova": "Extremely powerful being with tremedous telekinetic powers and the ability to rearrange the molecular structure of matter and energy, even up to cosmic scale.",
-	"Sigma Proioxis": "A nigh-omnipotent cosmological entity, with vast matter and energy manipulation abilities that help you push the boundaries of the Universe itself.",
-    "Acallaris": "Primordial being that predate the universe, involved with the creation of life and powerful beyond mortal comprehension, existing as myths to the oldest species in the universe.",
-	"One Above All": "Creator of everything.",
-
-    // Fundamentals
-    "Concentration": "Improve your learning speed through practising intense concentration activities.",
-    "Productivity": "Learn to procrastinate less at work and receive more job experience per day.",
-    "Bargaining": "Study the tricks of the trade and persuasive skills to lower any type of expense.",
-    "Meditation": "Fill your mind with peace and tranquility to tap into greater happiness from within.",
-
-    // Combat
-    "Strength": "Condition your body and strength through harsh training. Stronger individuals are paid more in the military.",
-    "Battle Tactics": "Create and revise battle strategies, improving experience gained in the military.",
-    "Muscle Memory": "Strengthen your neurons through habit and repetition, improving strength gains throughout the body.",
-
-    // Magic
-    "Mana Control": "Strengthen your mana channels throughout your body, aiding you in becoming a more powerful magical user.",
-    "Life Essence": "Lengthen your lifespan through the means of magic. However, is this truly the immortality you have tried seeking for...?",
-    "Time Warping": "Bend space and time through forbidden techniques, speeding up your learning processes.",
-    "Astral Body": "Lengthen your lifespan drastically beyond comprehension by harnessing ethereal energy.",
-	"Temporal Dimension": "Create your own pocket dimension where centuries go by in mere seconds.",
-	"All Seeing Eye": "As the highest rank of T.A.A, all funds go directly to you.",
-	"Brainwashing": "A technique designed to manipulate human thought and action against their desire.",
-
-    // Dark Magic - Evil Required
-    "Dark Influence": "Encompass yourself with formidable power bestowed upon you by evil, allowing you to pick up and absorb any job or skill with ease.",
-    "Evil Control": "Tame the raging and growing evil within you, improving evil gain in-between rebirths.",
-    "Intimidation": "Learn to emit a devilish aura which strikes extreme fear into other merchants, forcing them to give you heavy discounts.",
-    "Demon Training": "A mere human body is too feeble and weak to withstand evil. Train with forbidden methods to slowly manifest into a demon, capable of absorbing knowledge rapidly.",
-    "Blood Meditation": "Grow and culture the evil within you through the sacrifice of other living beings, drastically increasing evil gain.",
-    "Demon's Wealth": "Through the means of dark magic, multiply the raw matter of the coins you receive from your job.",
-	"Dark Knowledge": "Sealed for a very long time, you utilize these forbidden texts for your own personal gain.",
-	"Void Influence": "Tapping into the powers of the Void while combining them with evil grants you an unlimited potential.",
-	"Time Loop": "Mastery is achieved when 'telling time' becomes 'telling time what to do'.",
-	"Evil Incarnate": "You have became the very thing you swore to destroy.",
-
-	// Void Manipulation
-	"Absolute Wish": "The power to fulfill absolutely any and all wishes without any limitations.",
-    "Void Amplification": "You surrender yourself to the Void, making it easier to take control of you.",
-    "Mind Release": "In a trance like state, you feel the Void amplifying your thoughts, perception, memories, emotions and personality.",
-	"Ceaseless Abyss": "Never ending torture, you swore to serve the Void for the rest of your existence.",
-	"Void Symbiosis": "A symbiotic relationship that helps you become one with the Void.",
-	"Void Embodiment": "If thou gaze long into an abyss, the abyss will also gaze into thee.",
-	"Abyss Manipulation": "Allows you to shape your own reality within the Void itself.",
-
-	// Celestial Powers
-	"Cosmic Longevity": "You have seen it all, from the very beginning to the very end.",
-	"Cosmic Recollection": "Being able to exist in multiple parallel timelines and manipulating you parallel selves, influencing their lives as you see fit.",
-	"Essence Collector": "Exploit the unlimited potential of multiverse energies and collect its resources.",
-	"Galactic Command": "Absolute power corrupts absolutely.",
-
-	// Almightiness
-	"Yin Yang": "Born from chaos when the universe was first created, believed to exist in harmony, balancing evil and good.",
-	"Parallel Universe": "Self-contained plane of existence, co-existing with one's own, helping you restore fragments of your forgotten power.",
-	"Higher Dimensions": "By possesing the power to partially alter the laws of physics and transceding lower dimensional spaces, your existence becomes never-ending.",
-	"Epiphany": "You become one with everything.",
-
-    // Darkness
-    "Dark Prince": "You can increase your intelligence at an alarming rate due to your access to all libraries in the universe.",
-    "Dark Ruler": "Ruling the universe allows you to collect more Dark Matter from your subordinates.",
-    "Immortal Ruler": "You have only one goal: ruling this universe till infinity.",
-    "Dark Magician": "By performing forbidden magic on your subordinates, you can extract every last drop of Essence from them.",
-    "Universal Ruler": "No one dares to challenge your rule when ruling with an iron fist.",
-    "Blinded By Darkness": "Blinded by darkness, you can no longer control yourself. You start to destroy everything in existance to calm yourself.",
-
-    // Properties
-    "Homeless": "Sleep on the uncomfortable, filthy streets while almost freezing to death every night. It cannot get any worse than this.",
-    "Tent": "A thin sheet of tattered cloth held up by a couple of feeble, wooden sticks. Horrible living conditions but at least you have a roof over your head.",
-    "Wooden Hut": "Shabby logs and dirty hay glued together with horse manure. Much more sturdy than a tent, however, the stench isn't very pleasant.",
-    "Cottage": "Structured with a timber frame and a thatched roof. Provides decent living conditions for a fair price.",
-    "House": "A building formed from stone bricks and sturdy timber, which contains a few rooms. Although quite expensive, it is a comfortable abode.",
-    "Large House": "Much larger than a regular house, which boasts even more rooms and multiple floors. The building is quite spacious but comes with a hefty price tag.",
-    "Small Palace": "A very rich and meticulously built structure rimmed with fine metals such as silver. Extremely high expenses to maintain for a lavish lifestyle.",
-    "Grand Palace": "A grand residence completely composed of gold and silver. Provides the utmost luxurious and comfortable living conditions possible for a ludicrous price.",
-	"Town Ruler": "You rule your very own community in your small town, owning multiple establishments.",
-    "City Ruler": "As the highest ranking official, you manage and oversee everything that happens. While your pay is astronomical, so are your expenses.",
-	"Nation Ruler": "You reign the whole nation. While your riches may be corrupted, everything you see belongs to you.",
-	"Pocket Dimension": "A Dimension just for you that can be summoned at will. What happens there stays there.",
-	"Void Realm": "Unknown how or when the Void realm came into existence, containing elements which don’t exist outside of its dimensional plane are now all to your disposal",
-	"Void Universe": "Predating our own universe, the Void has an unlimited amount of space for your belongings, if you are willing to submit to it.",
-	"Astral Realm": "Beneath personality and ego lays the source of our deep character, our personhood. Here are the psychic senses, our deep mind and emotions, symbols and inner reality.",
-    "Galactic Throne": "You sit on your throne, overseeing the existence itself.",
-    "Spaceship": "Your own personal cosmic house.",
-    "Planet": "A planet with the sole purpose of housing you and your family.",
-    "The Universe": "The universe is now yours.",
-
-    //Misc
-    "Book": "A place to write down all your thoughts and discoveries, allowing you to learn a lot more quickly.",
-    "Dumbbells": "Heavy tools used in strenuous exercise to toughen up and accumulate strength even faster than before.",
-    "Personal Squire": "Assists you in completing day to day activities, giving you more time to be productive at work.",
-    "Steel Longsword": "A fine blade used to slay enemies even quicker in combat and therefore gain more experience.",
-    "Butler": "Keeps your household clean at all times and also prepares three delicious meals per day, leaving you in a happier, stress-free mood.",
-    "Sapphire Charm": "Embedded with a rare sapphire, this charm activates more mana channels within your body, providing a much easier time learning magic.",
-    "Study Desk": "A dedicated area which provides many fine stationary and equipment designed for furthering your progress in research.",
-    "Library": "Stores a collection of books, each containing vast amounts of information from basic life skills to complex magic spells.",
-	"Observatory": "Used for observing terrestrial, marine and celestial events.",
-	"Mind's Eye": "Lets you see memories, remember images, and even see new pictures and ideas.",
-	"Void Necklace": "Helps you shape and manipulate void matter, even transmute and rebuild it into anything of your choosing.",
-	"Void Armor": "Generates an innate armor as a part of you body, which is resistant to attacks, harm or pain.",
-	"Void Blade": "Forged from void dust and dark matter, this blade can slash through dimensional barriers. It's a weapon of choice for every Void Reaver.",
-	"Void Orb": "When the orb touches non void entities, it instantly disintegrates them by harnessing its power from Void realm.",
-	"Void Dust": "Purest version of void created material; a teaspoon of it is as heavy as a small planet.",
-	"Celestial Robe": "The most powerful and essential equipment of any Celestial. Acts as a source of infinite power.",
-	"Universe Fragment": "From the time the universe was born. Can create more small universes.",
-    "Multiverse Fragment": "Came into existance long before our universe was created, this strange looking object with no shape radiates unlimited energy.",
-
-    //Essence Milestones
-    "Magic Eye": "The Eye in your Amulet starts to glow.",
-    "Almighty Eye": "The Eye in your Amulet shines like a star.",
-    "Deal with the Devil": "You made a deal with the Devil.",
-    "Transcendent Master": "You've mastered Transcendence.",
-    "Eternal Time": "Does time matter now?",
-    "Hell Portal": "You've opened a portal to Hell.",
-    "Inferno": "You are at the last level of Hell. What is next?",
-    "God's Blessings": "God bless you!",
-    "Faint Hope": "Maybe there is hope?",
-    "New Beginning": "Try to upgrade One Above All to level 2000",
-
-    //Heroic Milestones
-    "Rise of Great Heroes": "Every active Great job or skill will increase Essence gain a bit.",
-    "Lazy Heroes": "Total Hero XP multiplier is 5e20",
-    "Dirty Heroes": "Total Hero XP multiplier is 5e35",
-    "Angry Heroes": "Total Hero XP multiplier is 5e50",
-    "Tired Heroes": "Total Hero XP multiplier is 5e65",
-    "Scared Heroes": "Total Hero XP multiplier is 5e80",
-    "Good Heroes": "Total Hero XP multiplier is 5e95",
-    "Funny Heroes": "Total Hero XP multiplier is 5e120",
-    "Beautiful Heroes": "Total Hero XP multiplier is 5e170",
-    "Awesome Heroes": "Total Hero XP multiplier is 5e180",
-    "Furious Heroes": "Total Hero XP multiplier is 5e198",
-    "Superb Heroes": "Total Hero XP multiplier is 5e201",
-    "A new beginning": "Unlocks the ability to reset for Dark Matter",
-
-    // Dark Milestones
-    "Mind Control": "Control the Devil by making him give you even more Evil per second",
-    "Galactic Emperor": "Commander of the Galactic Council grants you the privilege to automatically collect Essence from the nearby planets",
-    "Dark Matter Harvester": "Harvest the universe to extract even more Dark Matter from it.",
-    "A Dark Era": "Start a new era of Dark Matter.",
-    "Dark Orbiter": "Using some wizardry you can improve your Dark Orb generators massively.",
-    "Dark Matter Mining": "Mine a huge amount of Dark Matter from each planet you visit.",
 }
 
 function getBindedTaskEffect(taskName) {

--- a/js/main.js
+++ b/js/main.js
@@ -209,7 +209,12 @@ const itemBaseData = {
     "Galactic Throne": { name: "Galactic Throne", expense: 5000000000000000, effect: 300000, heromult: 13, heroeffect: 2e35 },
     "Spaceship": { name: "Spaceship", expense: 1000000000000000000, effect: 1500000, heromult: 15, heroeffect: 5e42 },
     "Planet": { name: "Planet", expense: 1e22, effect: 5000000, heromult: 16, heroeffect: 5e46 },
-    "The Universe": { name: "The Universe", expense: 1e24, effect: 50000000, heromult: 17, heroeffect: 5e49 },
+    "Ringworld": { name: "Ringworld", expense: 1e24, effect: 50000000, heromult: 17, heroeffect: 5e49 },
+    "Stellar Neighborhood": { name: "Stellar Neighborhood", expense: 1e27, effect: 60000000, heromult: 17, heroeffect: 6e49 },
+    "Galaxy": { name: "Galaxy", expense: 1e30, effect: 70000000, heromult: 18, heroeffect: 7e49 },
+    "Supercluster": { name: "Supercluster", expense: 1e33, effect: 80000000, heromult: 20, heroeffect: 8e49 },
+    "Galaxy Filament": { name: "Galaxy Filament", expense: 1e36, effect: 90000000, heromult: 25, heroeffect: 9e49 },
+    "Observable Universe": { name: "Observable Universe", expense: 1e39, effect: 100000000, heromult: 30, heroeffect: 1e50 },
 
     "Book": { name: "Book", expense: 10, effect: 1.5, description: "Ability XP", heromult: 2 },
     "Dumbbells": { name: "Dumbbells", expense: 50, effect: 1.5, description: "Strength XP", heromult: 2 },
@@ -285,7 +290,7 @@ const skillCategories = {
 }
 
 const itemCategories = {
-    "Properties": ["Homeless", "Tent", "Wooden Hut", "Cottage", "House", "Large House", "Small Palace", "Grand Palace", "Town Ruler", "City Ruler", "Nation Ruler", "Pocket Dimension", "Void Realm", "Void Universe", "Astral Realm", "Galactic Throne", "Spaceship", "Planet", "The Universe"],
+    "Properties": ["Homeless", "Tent", "Wooden Hut", "Cottage", "House", "Large House", "Small Palace", "Grand Palace", "Town Ruler", "City Ruler", "Nation Ruler", "Pocket Dimension", "Void Realm", "Void Universe", "Astral Realm", "Galactic Throne", "Spaceship", "Planet", "Ringworld", "Stellar Neighborhood", "Galaxy", "Supercluster", "Galaxy Filament", "Observable Universe"],
     "Misc": ["Book", "Dumbbells", "Personal Squire", "Steel Longsword", "Butler", "Sapphire Charm", "Study Desk", "Library", "Observatory", "Mind's Eye", "Void Necklace", "Void Armor", "Void Blade", "Void Orb", "Void Dust", "Celestial Robe", "Universe Fragment", "Multiverse Fragment"]
 }
 
@@ -884,7 +889,7 @@ function autoBuy() {
             const expense = item.getExpense()
 
             if (itemCategories['Properties'].indexOf(key) != -1) {
-                if (expense < income) {
+                if (expense < income && expense >= usedExpense) {
                     gameData.currentProperty = item
                     usedExpense = expense
                 }
@@ -1655,7 +1660,12 @@ gameData.requirements = {
     "Galactic Throne": new CoinRequirement([getItemElement("Galactic Throne")], [{ requirement: gameData.itemData["Galactic Throne"].getExpense() * 100 }]),
     "Spaceship": new CoinRequirement([getItemElement("Spaceship")], [{ requirement: gameData.itemData["Spaceship"].getExpense() * 100 }]),
     "Planet": new CoinRequirement([getItemElement("Planet")], [{ requirement: gameData.itemData["Planet"].getExpense() * 100 }]),
-    "The Universe": new CoinRequirement([getItemElement("The Universe")], [{ requirement: gameData.itemData["The Universe"].getExpense() * 100 }]),
+    "Ringworld": new CoinRequirement([getItemElement("Ringworld")], [{ requirement: gameData.itemData["Ringworld"].getExpense() * 100 }]),
+    "Stellar Neighborhood": new CoinRequirement([getItemElement("Stellar Neighborhood")], [{ requirement: gameData.itemData["Stellar Neighborhood"].getExpense(true) * 100 }]),
+    "Galaxy": new CoinRequirement([getItemElement("Galaxy")], [{ requirement: gameData.itemData["Galaxy"].getExpense(true) * 1e5 }]),
+    "Supercluster": new CoinRequirement([getItemElement("Supercluster")], [{ requirement: gameData.itemData["Supercluster"].getExpense(true) * 1e8 }]),
+    "Galaxy Filament": new CoinRequirement([getItemElement("Galaxy Filament")], [{ requirement: gameData.itemData["Galaxy Filament"].getExpense(true) * 1e10 }]),
+    "Observable Universe": new CoinRequirement([getItemElement("Observable Universe")], [{ requirement: gameData.itemData["Observable Universe"].getExpense(true) * 1e14 }]),
 
     // Misc
     "Book": new CoinRequirement([getItemElement("Book")], [{requirement: 0}]),

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -122,9 +122,14 @@ const tooltips = {
     "Void Universe": "Predating our own universe, the Void has an unlimited amount of space for your belongings, if you are willing to submit to it.",
     "Astral Realm": "Beneath personality and ego lays the source of our deep character, our personhood. Here are the psychic senses, our deep mind and emotions, symbols and inner reality.",
     "Galactic Throne": "You sit on your throne, overseeing the existence itself.",
-    "Spaceship": "Your own personal cosmic house.",
+    "Spaceship": "Your own personal cosmic house, able to travel anywhere in the universe at 99.99% of the speed of light.",
     "Planet": "A planet with the sole purpose of housing you and your family.",
-    "The Universe": "The universe is now yours.",
+    "Ringworld": "A construct with the mass of Jupiter and a surface area millions of times that of Earth, capable of housing trillions of humans and other animals including alien species. The expenses are literally astronomical due to the maintenance involved in keeping the structure stable and the inside area habitable, but the massive living space is worth it.",
+    "Stellar Neighborhood": "A fully colonized network of stars and star systems spanning dozens of light years is ready for you to explore and call home.",
+    "Galaxy": "You rule your very own galaxy the size of the Milky Way, with billions of planets organized into thousands of different states all under your control. While your power is astronomical, so are your responsibilities.",
+    "Supercluster": "A cluster of galactic groups spanning hundreds of millions of light years across and containing thousands of galaxies is under your control.",
+    "Galaxy Filament": "One of the largest known structures of the universe, containing dozens of superclusters and millions of galaxies.",
+    "Observable Universe": "You did it! You finally rule the entire universe...or do you?",
 
     // Misc
     "Book": "A place to write down all your thoughts and discoveries, allowing you to learn a lot more quickly.",

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -1,0 +1,183 @@
+const tooltips = {
+    // Common work
+    "Beggar": "Struggle day and night for a couple of copper coins. It feels like you are at the brink of death each day.",
+    "Farmer": "Plow the fields and grow the crops. It's not much but it's honest work.",
+    "Fisherman": "Reel in various fish and sell them for a handful of coins. A relaxing but still poor paying job.",
+    "Miner": "Delve into dangerous caverns and mine valuable ores. The pay is quite meager compared to the risk involved.",
+    "Blacksmith": "Smelt ores and carefully forge weapons for the military. A respectable and OK paying commoner job.",
+    "Merchant": "Travel from town to town, bartering fine goods. The job pays decently well and is a lot less manually-intensive.",
+
+    // Military
+    "Squire": "Carry around your knight's shield and sword along the battlefield. Very meager pay but the work experience is quite valuable.",
+    "Footman": "Put down your life to battle with enemy soldiers. A courageous, respectable job but you are still worthless in the grand scheme of things.",
+    "Veteran footman": "More experienced and useful than the average footman, take out the enemy forces in battle with your might. The pay is not that bad.",
+    "Centenary": "By proving your skills with a bow, you were appointed to lead a small group of archers to ambush your enemies from a distance.",
+    "Knight": "Slash and pierce through enemy soldiers with ease, while covered in steel from head to toe. A decently paying and very respectable job.",
+    "Veteran Knight": "Utilising your unmatched combat ability, slaugher enemies effortlessly. Most footmen in the military would never be able to acquire such a well paying job like this.",
+    "Holy Knight": "Obliterate squadrons of enemy soldiers in one go with extraordinary proficiency, while wielding a magically imbued blade. Such a feared unit on the battlefield is paid extremely well.",
+    "Lieutenant General": "Feared by nations, obliterate entire armies in a blink of an eye. Roughly every century, only one holy knight is worthy of receiving such an esteemed title.",
+
+    // The Arcane Association
+    "Student": "Study the theory of mana and practice basic spells. There is minor pay to cover living costs; however, this is a necessary stage in becoming a mage.",
+    "Apprentice Mage": "Under the supervision of a skilled mage, perform basic spells against enemies in battle. Generous pay will be provided to cover living costs.",
+    "Adept Mage": "Turn the tides of battle through casting intermediate spells and mentor other apprentices. The pay for this particular job is extremely high.",
+    "Master Wizard": "Utilise advanced spells to ravage and destroy entire legions of enemy soldiers. Only a small percentage of mages deserve to attain this role and are rewarded with an insanely high pay.",
+    "Archmage": "Blessed with unparalleled talent, perform unbelievable feats with magic at will. It is said that an archmage has enough destructive power to wipe an empire off the map.",
+    "Chronomancer": "Specialize in harnessing temporal energies that alter the flow of time with supernatural divinations and otherwordly expertise.",
+    "Chairman": "Spend your days administrating The Arcane Association and investigate the concepts of true immortality. The chairman receives ludicrous amounts of pay daily.",
+    "Imperator": "You wield an unlimited power, making you unstoppable. By ruling with an iron fist, everyone in the Arcane Association has to obey your commands.",
+
+    // The Void
+    "Corrupted": "Corrupted by Void, you are slowly turning into a slave with no free will, just to serve the Void for the rest of eternity... Can you resist it, or will it consume you forever?",
+    "Void Slave": "Each day, you are succumbing to the Void more and more. Can you hold onto your humanity for a bit longer, or will you let the Void devour you?",
+    "Void Fiend": "You become an inquisitive yet putrid creature that siphons life from everything around you.",
+    "Abyss Anomaly": "Screaming into existence, you become a manifestation of the unknowable nothingness that lies beyond.",
+    "Void Wraith": "Damned soul... a shadow of your former self, lingering between realms and consumed by void... Can you ever find peace?",
+    "Void Reaver": "There are few who may tread the paths between worlds, these powers grant you an ability to generate fields of void energy that devour all living things.",
+    "Void Lord": "You gazed into the dark heart of the Void long enough to become one of the most powerful and feared beings. All lesser void creatures are at your command.",
+    "Abyss God": "Creator of the Void, a vast canvas of blackness and nothingness, in which the concept of its existence defies all logic. Nothing will escape you.",
+
+    // Galactic Council
+    "Eternal Wanderer": "With the powers bestowed upon you by an unknown entity, you wander around, visiting places revered and feared in search of answers.",
+    "Nova": "Extremely powerful being with tremedous telekinetic powers and the ability to rearrange the molecular structure of matter and energy, even up to cosmic scale.",
+    "Sigma Proioxis": "A nigh-omnipotent cosmological entity, with vast matter and energy manipulation abilities that help you push the boundaries of the Universe itself.",
+    "Acallaris": "Primordial being that predate the universe, involved with the creation of life and powerful beyond mortal comprehension, existing as myths to the oldest species in the universe.",
+    "One Above All": "Creator of everything.",
+
+    // Fundamentals
+    "Concentration": "Improve your learning speed through practising intense concentration activities.",
+    "Productivity": "Learn to procrastinate less at work and receive more job experience per day.",
+    "Bargaining": "Study the tricks of the trade and persuasive skills to lower any type of expense.",
+    "Meditation": "Fill your mind with peace and tranquility to tap into greater happiness from within.",
+
+    // Combat
+    "Strength": "Condition your body and strength through harsh training. Stronger individuals are paid more in the military.",
+    "Battle Tactics": "Create and revise battle strategies, improving experience gained in the military.",
+    "Muscle Memory": "Strengthen your neurons through habit and repetition, improving strength gains throughout the body.",
+
+    // Magic
+    "Mana Control": "Strengthen your mana channels throughout your body, aiding you in becoming a more powerful magical user.",
+    "Life Essence": "Lengthen your lifespan through the means of magic. However, is this truly the immortality you have tried seeking for...?",
+    "Time Warping": "Bend space and time through forbidden techniques, speeding up your learning processes.",
+    "Astral Body": "Lengthen your lifespan drastically beyond comprehension by harnessing ethereal energy.",
+    "Temporal Dimension": "Create your own pocket dimension where centuries go by in mere seconds.",
+    "All Seeing Eye": "As the highest rank of T.A.A, all funds go directly to you.",
+    "Brainwashing": "A technique designed to manipulate human thought and action against their desire.",
+
+    // Dark Magic - Evil Required
+    "Dark Influence": "Encompass yourself with formidable power bestowed upon you by evil, allowing you to pick up and absorb any job or skill with ease.",
+    "Evil Control": "Tame the raging and growing evil within you, improving evil gain in-between rebirths.",
+    "Intimidation": "Learn to emit a devilish aura which strikes extreme fear into other merchants, forcing them to give you heavy discounts.",
+    "Demon Training": "A mere human body is too feeble and weak to withstand evil. Train with forbidden methods to slowly manifest into a demon, capable of absorbing knowledge rapidly.",
+    "Blood Meditation": "Grow and culture the evil within you through the sacrifice of other living beings, drastically increasing evil gain.",
+    "Demon's Wealth": "Through the means of dark magic, multiply the raw matter of the coins you receive from your job.",
+    "Dark Knowledge": "Sealed for a very long time, you utilize these forbidden texts for your own personal gain.",
+    "Void Influence": "Tapping into the powers of the Void while combining them with evil grants you an unlimited potential.",
+    "Time Loop": "Mastery is achieved when 'telling time' becomes 'telling time what to do'.",
+    "Evil Incarnate": "You have became the very thing you swore to destroy.",
+
+    // Void Manipulation
+    "Absolute Wish": "The power to fulfill absolutely any and all wishes without any limitations.",
+    "Void Amplification": "You surrender yourself to the Void, making it easier to take control of you.",
+    "Mind Release": "In a trance like state, you feel the Void amplifying your thoughts, perception, memories, emotions and personality.",
+    "Ceaseless Abyss": "Never ending torture, you swore to serve the Void for the rest of your existence.",
+    "Void Symbiosis": "A symbiotic relationship that helps you become one with the Void.",
+    "Void Embodiment": "If thou gaze long into an abyss, the abyss will also gaze into thee.",
+    "Abyss Manipulation": "Allows you to shape your own reality within the Void itself.",
+
+    // Celestial Powers
+    "Cosmic Longevity": "You have seen it all, from the very beginning to the very end.",
+    "Cosmic Recollection": "Being able to exist in multiple parallel timelines and manipulating you parallel selves, influencing their lives as you see fit.",
+    "Essence Collector": "Exploit the unlimited potential of multiverse energies and collect its resources.",
+    "Galactic Command": "Absolute power corrupts absolutely.",
+
+    // Almightiness
+    "Yin Yang": "Born from chaos when the universe was first created, believed to exist in harmony, balancing evil and good.",
+    "Parallel Universe": "Self-contained plane of existence, co-existing with one's own, helping you restore fragments of your forgotten power.",
+    "Higher Dimensions": "By possesing the power to partially alter the laws of physics and transceding lower dimensional spaces, your existence becomes never-ending.",
+    "Epiphany": "You become one with everything.",
+
+    // Darkness
+    "Dark Prince": "You can increase your intelligence at an alarming rate due to your access to all libraries in the universe.",
+    "Dark Ruler": "Ruling the universe allows you to collect more Dark Matter from your subordinates.",
+    "Immortal Ruler": "You have only one goal: ruling this universe till infinity.",
+    "Dark Magician": "By performing forbidden magic on your subordinates, you can extract every last drop of Essence from them.",
+    "Universal Ruler": "No one dares to challenge your rule when ruling with an iron fist.",
+    "Blinded By Darkness": "Blinded by darkness, you can no longer control yourself. You start to destroy everything in existance to calm yourself.",
+
+    // Properties
+    "Homeless": "Sleep on the uncomfortable, filthy streets while almost freezing to death every night. It cannot get any worse than this.",
+    "Tent": "A thin sheet of tattered cloth held up by a couple of feeble, wooden sticks. Horrible living conditions but at least you have a roof over your head.",
+    "Wooden Hut": "Shabby logs and dirty hay glued together with horse manure. Much more sturdy than a tent, however, the stench isn't very pleasant.",
+    "Cottage": "Structured with a timber frame and a thatched roof. Provides decent living conditions for a fair price.",
+    "House": "A building formed from stone bricks and sturdy timber, which contains a few rooms. Although quite expensive, it is a comfortable abode.",
+    "Large House": "Much larger than a regular house, which boasts even more rooms and multiple floors. The building is quite spacious but comes with a hefty price tag.",
+    "Small Palace": "A very rich and meticulously built structure rimmed with fine metals such as silver. Extremely high expenses to maintain for a lavish lifestyle.",
+    "Grand Palace": "A grand residence completely composed of gold and silver. Provides the utmost luxurious and comfortable living conditions possible for a ludicrous price.",
+    "Town Ruler": "You rule your very own community in your small town, owning multiple establishments.",
+    "City Ruler": "As the highest ranking official, you manage and oversee everything that happens. While your pay is astronomical, so are your expenses.",
+    "Nation Ruler": "You reign the whole nation. While your riches may be corrupted, everything you see belongs to you.",
+    "Pocket Dimension": "A Dimension just for you that can be summoned at will. What happens there stays there.",
+    "Void Realm": "Unknown how or when the Void realm came into existence, containing elements which don’t exist outside of its dimensional plane are now all to your disposal",
+    "Void Universe": "Predating our own universe, the Void has an unlimited amount of space for your belongings, if you are willing to submit to it.",
+    "Astral Realm": "Beneath personality and ego lays the source of our deep character, our personhood. Here are the psychic senses, our deep mind and emotions, symbols and inner reality.",
+    "Galactic Throne": "You sit on your throne, overseeing the existence itself.",
+    "Spaceship": "Your own personal cosmic house.",
+    "Planet": "A planet with the sole purpose of housing you and your family.",
+    "The Universe": "The universe is now yours.",
+
+    // Misc
+    "Book": "A place to write down all your thoughts and discoveries, allowing you to learn a lot more quickly.",
+    "Dumbbells": "Heavy tools used in strenuous exercise to toughen up and accumulate strength even faster than before.",
+    "Personal Squire": "Assists you in completing day to day activities, giving you more time to be productive at work.",
+    "Steel Longsword": "A fine blade used to slay enemies even quicker in combat and therefore gain more experience.",
+    "Butler": "Keeps your household clean at all times and also prepares three delicious meals per day, leaving you in a happier, stress-free mood.",
+    "Sapphire Charm": "Embedded with a rare sapphire, this charm activates more mana channels within your body, providing a much easier time learning magic.",
+    "Study Desk": "A dedicated area which provides many fine stationary and equipment designed for furthering your progress in research.",
+    "Library": "Stores a collection of books, each containing vast amounts of information from basic life skills to complex magic spells.",
+    "Observatory": "Used for observing terrestrial, marine and celestial events.",
+    "Mind's Eye": "Lets you see memories, remember images, and even see new pictures and ideas.",
+    "Void Necklace": "Helps you shape and manipulate void matter, even transmute and rebuild it into anything of your choosing.",
+    "Void Armor": "Generates an innate armor as a part of you body, which is resistant to attacks, harm or pain.",
+    "Void Blade": "Forged from void dust and dark matter, this blade can slash through dimensional barriers. It's a weapon of choice for every Void Reaver.",
+    "Void Orb": "When the orb touches non void entities, it instantly disintegrates them by harnessing its power from Void realm.",
+    "Void Dust": "Purest version of void created material; a teaspoon of it is as heavy as a small planet.",
+    "Celestial Robe": "The most powerful and essential equipment of any Celestial. Acts as a source of infinite power.",
+    "Universe Fragment": "From the time the universe was born. Can create more small universes.",
+    "Multiverse Fragment": "Came into existance long before our universe was created, this strange looking object with no shape radiates unlimited energy.",
+
+    // Essence Milestones
+    "Magic Eye": "The Eye in your Amulet starts to glow.",
+    "Almighty Eye": "The Eye in your Amulet shines like a star.",
+    "Deal with the Devil": "You made a deal with the Devil.",
+    "Transcendent Master": "You've mastered Transcendence.",
+    "Eternal Time": "Does time matter now?",
+    "Hell Portal": "You've opened a portal to Hell.",
+    "Inferno": "You are at the last level of Hell. What is next?",
+    "God's Blessings": "God bless you!",
+    "Faint Hope": "Maybe there is hope?",
+    "New Beginning": "Try to upgrade One Above All to level 2000",
+
+    // Heroic Milestones
+    "Rise of Great Heroes": "Every active Great job or skill will increase Essence gain a bit.",
+    "Lazy Heroes": "Total Hero XP multiplier is 5e20",
+    "Dirty Heroes": "Total Hero XP multiplier is 5e35",
+    "Angry Heroes": "Total Hero XP multiplier is 5e50",
+    "Tired Heroes": "Total Hero XP multiplier is 5e65",
+    "Scared Heroes": "Total Hero XP multiplier is 5e80",
+    "Good Heroes": "Total Hero XP multiplier is 5e95",
+    "Funny Heroes": "Total Hero XP multiplier is 5e120",
+    "Beautiful Heroes": "Total Hero XP multiplier is 5e170",
+    "Awesome Heroes": "Total Hero XP multiplier is 5e180",
+    "Furious Heroes": "Total Hero XP multiplier is 5e198",
+    "Superb Heroes": "Total Hero XP multiplier is 5e201",
+    "A new beginning": "Unlocks the ability to reset for Dark Matter",
+
+    // Dark Milestones
+    "Mind Control": "Control the Devil by making him give you even more Evil per second",
+    "Galactic Emperor": "Commander of the Galactic Council grants you the privilege to automatically collect Essence from the nearby planets",
+    "Dark Matter Harvester": "Harvest the universe to extract even more Dark Matter from it.",
+    "A Dark Era": "Start a new era of Dark Matter.",
+    "Dark Orbiter": "Using some wizardry you can improve your Dark Orb generators massively.",
+    "Dark Matter Mining": "Mine a huge amount of Dark Matter from each planet you visit.",
+}


### PR DESCRIPTION
The universe is at least a trillion, trillion times bigger than a planet, which means there's definitely room for several new properties.

All of the new properties are unlocked after going Heroic, with the last one requiring a googol dollars to unlock or the equivalent in other currencies. This is to give players something to do with their 5e5 Dark Matter and an incentive to max out everything available, as the last property can be unlocked in under 10 minutes from the start of a rebirth if done right.

Each property has just 20% more happiness (additive) than the last after the previous endgame property; this is to avoid breaking other future plans, but the effects can be strengthened if needed (my original intention was for the properties to gradually ramp up to around 1e60 Happiness at the end).

<details>

<summary>Original property effects</summary>

| Property | Happiness | Heroic Happiness |
| -------- | --------- | ---------------- |
| Ringworld            | ×5e7    | ×5e49  |
| Stellar Neighborhood | ×1e8    | ×1e52  |
| Galaxy               | ×1e9    | ×1e54  |
| Supercluster         | ×1e10   | ×1e56  |
| Galaxy Filament      | ×1e11   | ×1e58  |
| Observable Universe  | ×1e12   | ×1e60  |

</details>

I found a bug where the "Currency notation" would say "Medieval" and the layout would be set to "Standard" on every (re)load, but I haven't found a fix for that bug yet.

There was also a bug where if the properties were registered in the wrong order, the property automatically selected may not be the best affordable. That is now fixed; the autobuy mechanism attempts to select the most expensive affordable property every game tick.