### PR TITLE
Fix: most settings were not loaded from save on game load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1291,15 +1291,15 @@ function peekThemeFromSave() {
     }
 }
 
-function peekFontSizeFromSave() {
+function peekSettingFromSave(setting) {
     try {
         const save = localStorage.getItem("gameDataSave")
         if (save == null)
-            return 1
+            return gameData.settings[setting]
         const gameDataSave = JSON.parse(save)
-        if (gameDataSave.settings == undefined || gameDataSave.settings.fontSize == undefined)
-            return 1
-        return gameDataSave.settings.fontSize
+        if (gameDataSave.settings == undefined || gameDataSave.settings[setting] == undefined)
+            return gameData.settings[setting]
+        return gameDataSave.settings[setting]
     } catch (error) {
         console.error(error)
         console.log(localStorage.getItem("gameDataSave"))

--- a/js/ui.js
+++ b/js/ui.js
@@ -8,13 +8,13 @@ function initializeUI() {
     createAllRows(itemCategories, "itemTable")
     createAllRows(milestoneCategories, "milestoneTable")
 
-    setLayout(gameData.settings.layout)
-    setFontSize(peekFontSizeFromSave())
-    setNotation(gameData.settings.numberNotation)
-    setCurrency(gameData.settings.currencyNotation)
-    setStickySidebar(gameData.settings.stickySidebar)
+    setLayout(peekSettingFromSave("layout"))
+    setFontSize(peekSettingFromSave("fontSize"))
+    setNotation(peekSettingFromSave("numberNotation"))
+    setCurrency(peekSettingFromSave("currencyNotation"))
+    setStickySidebar(peekSettingFromSave("stickySidebar"))
 
-    setTheme(gameData.settings.theme)
+    setTheme(peekSettingFromSave("theme"))
 }
 
 function updateUI() {


### PR DESCRIPTION
The font size was loaded from the save data during UI initialization, but the other settings weren't, causing things like layout and currency notation to visually reset whenever a player (re)loaded the game.

This is now fixed by replacing the `peekFontSizeFromSave` function with its more general counterpart, `peekSettingFromSave`, and using that new function where appropriate.