### PR TITLE
Add reset description for collapsing the universe

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@
 										<i style="color: rgb(200, 0, 0)">
 										If you decide to embrace evil, all of your levels, coins and even max levels will be reset.
 										You will be reborn as a fresh slate. However, you will unlock a new line of skills and gain
-										<b><span id="evilGainDisplay"></span> evil</b>, and which will heavily impact your future lives.
+										<b><span id="evilGainDisplay"></span> evil</b>, which will heavily impact your future lives.
 										</i>
 										<br>
 										<button class="w3-button button" style="margin-bottom: 0.4em; margin-top: 0.4em " onClick="rebirthTwo()">Embrace evil</button>
@@ -392,30 +392,36 @@
 										You have unlocked <b>"Galactic Council"</b> class category along with <b>"Celestial Powers"</b> abilities.
 										<i style="color: grey">
 										<br>
-										By clicking on <b>Transcend</b>, you will be reborn once again, losing all your coins, <b>evil</b> and current levels.
-										However your max level won't be erased but multiplied with <b>Cosmic Recollection</b> ability and you will gain
+										If you decide to <b>transcend</b>, you will be reborn once again, losing all your coins, <b>evil</b> and current levels.
+										However, your max levels won't be erased, but instead multiplied with the effect from the <b>Cosmic Recollection</b> ability and you will gain
 										<i style="color: rgb(24, 210, 217)">
 										<b><span id="essenceGainDisplay"></span> essence</b>,
 										</i>
 										along with new abilities that will boost you even further in your journey.
 										<br>
 										<i style="color: rgb(200, 0, 0)">
-										Transcend will only show up if you have the <b>Cosmic Recollection</b> ability unlocked!
+										Transcend will only appear if you have the <b>Cosmic Recollection</b> ability unlocked!
 										</i>
 										</i>
 										<br>
 										</i>
-									</li>
-									<li style="margin: 0.4em;" id="rebirthNote6" class="hidden">
-										<div style="margin-bottom: 0.4em;">
+										<div style="margin-bottom: 0.4em;" id="rebirthNote6" class="hidden">
 											<button class="w3-button button" style="margin-bottom: 0.4em; margin-top: 0.4em" onClick="rebirthThree()">Transcend</button>
 										</div>
 									</li>
 									<li style="margin: 0.4em;" id="rebirthNote7" class="hidden">
+										<i style="color: rgb(114, 83, 182)">
+										You are starting to become way too powerful. The end of the universe may be near...
+										</i>
 										<i style="color: grey">
-										You are starting to become way too powerful. The end of the universe may be near..
+										<br>
+										If you decide to <b>collapse the universe</b>, all of your levels, coins, max levels, evil, and <b>essence</b> will be reset. You will be reborn as a fresh slate in a new universe, with no memory of milestones and challenges from any of your past selves. In exchange, you will unlock a third new line of abilities and gain <i style="color: rgb(114, 83, 182)">
+										<b><span id="darkMatterGainDisplay"></span> Dark Matter</b>,
+										</i>
+										which will boost you much further in your journey across the multiverse.
 										</i>
 										<br>
+										<button class="w3-button button" style="margin-bottom: 0.4em; margin-top: 0.4em " onClick="rebirthFour()">Collapse the universe</button>
 									</li>
 								</ul>
 							</div>

--- a/js/main.js
+++ b/js/main.js
@@ -1520,7 +1520,7 @@ gameData.requirements = {
 	"Rebirth note 4": new AgeRequirement([document.getElementById("rebirthNote4")], [{requirement: 1000}]),
 	"Rebirth note 5": new AgeRequirement([document.getElementById("rebirthNote5")], [{requirement: 10000}]),
     "Rebirth note 6": new TaskRequirement([document.getElementById("rebirthNote6")], [{ task: "Cosmic Recollection", requirement: 1 }]),
-    "Rebirth note 7": new EssenceRequirement([document.getElementById("rebirthNote7")], [{ requirement: 2e10 }]),
+    "Rebirth note 7": new EssenceRequirement([document.getElementById("rebirthNote7")], [{ requirement: 5e10 }]),
 
     "Rebirth button 1": new AgeRequirement([document.getElementById("rebirthButton1")], [{ requirement: 65 }]),
     "Rebirth button 2": new AgeRequirement([document.getElementById("rebirthButton2")], [{ requirement: 200 }]),

--- a/js/ui.js
+++ b/js/ui.js
@@ -118,6 +118,7 @@ function renderSideBar() {
     document.getElementById("essenceGainButtonDisplay").textContent = "+" + format(getEssenceGain())
 
     document.getElementById("darkMatterDisplay").textContent = format(gameData.dark_matter)
+    document.getElementById("darkMatterGainDisplay").textContent = format(getDarkMatterGain())
     document.getElementById("darkMatterGainButtonDisplay").textContent = "+" + format(getDarkMatterGain())
 
     document.getElementById("darkOrbsDisplay").textContent = format(gameData.dark_orbs)


### PR DESCRIPTION
Adds a description for what will happen when collapsing the universe, and fix some grammar in earlier parts of amulet lore.

Preview when first reaching Dark Matter reset requirement:
![image](https://user-images.githubusercontent.com/37945304/211063962-cfb8f01c-375b-407d-b959-d2cb36abb387.png)
