### PR TITLE
Clarify the "reset Dark Matter Skills" prompt

### DIFF
--- a/js/dark_matter.js
+++ b/js/dark_matter.js
@@ -91,7 +91,7 @@ function buyAMiracle() {
 
 // Skill tree
 function resetSkillTree() {
-    if (confirm("Are you sure that you want to reset your skills?")) {
+    if (confirm("Are you sure that you want to reset your Dark Matter Skills?")) {
         gameData.dark_matter_shop.speed_is_life = 0
         gameData.dark_matter_shop.your_greatest_debt = 0
         gameData.dark_matter_shop.essence_collector = 0


### PR DESCRIPTION
The text in the confirmation prompt for resetting Dark Matter Skills now refers to them specifically instead of using a more general term.