### PR TITLE
Recognize Great Chairman in "Legends never die" challenge progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
 								<div id="legendsNeverDieChallenge" style="padding-top:2em">
 									<div class="text-caption challenge-title">5. Legends never die</div>
 									<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, happiness does nothing and Dark Magic XP effect is always 1x</div>
-									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach Chairman lvl <span id="challengeGoal5">1227</span></div>
+									<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <span id="challengeGoal5">Chairman lvl 1227</span></div>
 									<div id="challengeReward5" class="reward">Reward: Multiplies evil gain by x<span id="challengeEvilGainBuff">1</span></div>
 									<button id="challengeButton5" class="w3-button button" onclick="enterChallenge('legends_never_die')">Enter challenge</button>
 								</div>

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -33,7 +33,7 @@ function setChallengeProgress() {
         gameData.challenges.dance_with_the_devil = Math.max(gameData.challenges.dance_with_the_devil, Math.max(0, getEvilGain() - 10))
     }
     if (gameData.active_challenge == "legends_never_die") {
-        gameData.challenges.legends_never_die = Math.max(gameData.challenges.legends_never_die, gameData.taskData["Chairman"].level)
+        gameData.challenges.legends_never_die = Math.max(gameData.challenges.legends_never_die, getChallengeTaskGoalProgress("Chairman"))
     }
 }
 
@@ -51,7 +51,7 @@ function getChallengeBonus(challenge_name, current = false) {
         return softcap(Math.pow((current ? Math.max(0, getEvilGain() - 10) : gameData.challenges.dance_with_the_devil) + 1, 0.09), 2, 0.75)
     }
     if (challenge_name == "legends_never_die") {
-        return softcap(Math.pow((current ? gameData.taskData["Chairman"].level : gameData.challenges.legends_never_die) + 1, 0.85), 25, 0.6)
+        return softcap(Math.pow((current ? getChallengeTaskGoalProgress("Chairman") : gameData.challenges.legends_never_die) + 1, 0.85), 25, 0.6)
     }
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -503,7 +503,7 @@ function renderChallenges() {
     formatCoins(getChallengeGoal("rich_and_the_poor"), document.getElementById("challengeGoal2"))
     document.getElementById("challengeGoal3").textContent = format(getChallengeGoal("time_does_not_fly"))
     document.getElementById("challengeGoal4").textContent = format(getChallengeGoal("dance_with_the_devil"))
-    document.getElementById("challengeGoal5").textContent = formatLevel(Math.floor(getChallengeGoal("legends_never_die")))
+    document.getElementById("challengeGoal5").textContent = getFormattedChallengeTaskGoal("Chairman", Math.floor(getChallengeGoal("legends_never_die")))
 
     document.getElementById("challengeReward1").hidden = gameData.challenges.an_unhappy_life == 0
     document.getElementById("challengeReward2").hidden = gameData.challenges.rich_and_the_poor == 0

--- a/js/utils.js
+++ b/js/utils.js
@@ -217,3 +217,19 @@ function exponentialToRawNumberString(value) {
 
     return first + [...Array(exponent)].map(() => "0").join("")
 }
+
+function getChallengeTaskGoalProgress(taskName) {
+    if (!Object.keys(gameData.taskData).includes(taskName))
+        return 0
+    if (gameData.taskData[taskName].isHero)
+        return gameData.taskData[taskName].level * 1000
+    else
+        return gameData.taskData[taskName].level
+}
+
+function getFormattedChallengeTaskGoal(taskName, level) {
+    if (level < 100000)
+        return taskName + " lvl " + formatLevel(level)
+    else
+        return "Great " + taskName + " lvl " + formatLevel(Math.ceil(level / 1000))
+}


### PR DESCRIPTION
This allows Great Chairman to count towards challenge 5 ("Legends never die") progress much more quickly compared to regular Chairman, to better reward players who reach heroics in that challenge.

For example, if a player reached Great Chairman level 1,000, that would count the same as reaching 1 million regular Chairman levels in terms of challenge progress, similar to how 1,000 Great Concentration is equivalent to about 1 million regular Concentration in its effect.

The result is that with the right setup, an Evil gain multiplier of over 15kx from the challenge can be achieved, compared to just 500x before this change.

The added code is designed such that if any additional challenges have task level based goals, they can easily receive a boost in progress from the job/skill becoming heroic.