### PR TITLE
Keep track of reset time separately per prestige layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,12 +657,14 @@
 											<div id="statsRebirth1" class="hidden">
 												<ul>
 													<li>You have touched the eye <span id="rebirthOneCountDisplay"></span> times.</li>
+													<li>You have spent <span id="rebirthOneTimeDisplay"></span> in this life.</li>
 													<li>Your fastest touch is in <span id="rebirthOneFastestDisplay"></span>.</li>
 												</ul>
 											</div>
 											<div id="statsRebirth2" class="hidden">
 												<ul>
 													<li>You have embraced evil <span id="rebirthTwoCountDisplay"></span> times.</li>
+													<li>You have spent <span id="rebirthTwoTimeDisplay"></span> in this embrace.</li>
 													<li>Your fastest embrace is in <span id="rebirthTwoFastestDisplay"></span>.</li>
 													<li id="statsEvilGain" class="hidden">You gain <span id="evilPerSecondDisplay"></span> evil/s. Maximum <span id="maxEvilPerSecondDisplay"></span> evil/s was at <span id="maxEvilPerSecondRtDisplay"></span>.</li>
 												</ul>
@@ -670,13 +672,15 @@
 											<div id="statsRebirth3" class="hidden">
 												<ul>
 													<li>You have transcended <span id="rebirthThreeCountDisplay"></span> times.</li>
-													<li>Your fastest transcend is in <span id="rebirthThreeFastestDisplay"></span>.</li>
+													<li>You have spent <span id="rebirthThreeTimeDisplay"></span> in this transcension.</li>
+													<li>Your fastest transcension is in <span id="rebirthThreeFastestDisplay"></span>.</li>
 													<li id="statsEssenceGain" class="hidden">You gain <span id="essencePerSecondDisplay"></span> essence/s. Maximum <span id="maxEssencePerSecondDisplay"></span> essence/s was at <span id="maxEssencePerSecondRtDisplay"></span>.</li>
 												</ul>
 											</div>
 											<div id="statsRebirth4" class="hidden">
 												<ul>
 													<li>You have collapsed the universe <span id="rebirthFourCountDisplay"></span> times.</li>
+													<li>You have spent <span id="rebirthFourTimeDisplay"></span> in this collapse.</li>
 													<li>Your fastest collapse is in <span id="rebirthFourFastestDisplay"></span>.</li>
 												</ul>
 											</div>

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -1,6 +1,8 @@
 function enterChallenge(challengeName) {
     rebirthReset(false)
     gameData.active_challenge = challengeName
+    gameData.rebirthOneTime = 0
+    gameData.rebirthTwoTime = 0
 
     for (const taskName in gameData.taskData) {
         const task = gameData.taskData[taskName]
@@ -12,6 +14,8 @@ function exitChallenge() {
     setChallengeProgress()
     rebirthReset(false)    
     gameData.active_challenge = ""
+    gameData.rebirthOneTime = 0
+    gameData.rebirthTwoTime = 0
 
     for (const taskName in gameData.taskData) {
         const task = gameData.taskData[taskName]

--- a/js/main.js
+++ b/js/main.js
@@ -23,9 +23,13 @@ var gameData = {
     timeWarpingEnabled: true,
 
     rebirthOneCount: 0,
+    rebirthOneTime: 0,
     rebirthTwoCount: 0,
+    rebirthTwoTime: 0,
     rebirthThreeCount: 0,
+    rebirthThreeTime: 0,
     rebirthFourCount: 0,
+    rebirthFourTime: 0,
 
     currentJob: null,
     currentProperty: null,
@@ -961,6 +965,10 @@ function increaseRealtime() {
         return;
     gameData.realtime += 1.0 / updateSpeed;
     gameData.realtimeRun += 1.0 / updateSpeed;
+    gameData.rebirthOneTime += 1.0 / updateSpeed;
+    gameData.rebirthTwoTime += 1.0 / updateSpeed;
+    gameData.rebirthThreeTime += 1.0 / updateSpeed;
+    gameData.rebirthFourTime += 1.0 / updateSpeed;
 }
 
 function setTheme(index, reload=false) {
@@ -993,8 +1001,9 @@ function setTheme(index, reload=false) {
 
 function rebirthOne() {
     gameData.rebirthOneCount += 1
-    if (gameData.stats.fastest1 == null || gameData.realtime < gameData.stats.fastest1)
-        gameData.stats.fastest1 = gameData.realtime
+    if (gameData.stats.fastest1 == null || gameData.rebirthOneTime < gameData.stats.fastest1)
+        gameData.stats.fastest1 = gameData.rebirthOneTime
+    gameData.rebirthOneTime = 0
 
     rebirthReset()
 }
@@ -1003,8 +1012,10 @@ function rebirthTwo() {
     gameData.rebirthTwoCount += 1
     gameData.evil += getEvilGain()
 
-    if (gameData.stats.fastest2 == null || gameData.realtime < gameData.stats.fastest2)
-        gameData.stats.fastest2 = gameData.realtime
+    if (gameData.stats.fastest2 == null || gameData.rebirthTwoTime < gameData.stats.fastest2)
+        gameData.stats.fastest2 = gameData.rebirthTwoTime
+    gameData.rebirthOneTime = 0
+    gameData.rebirthTwoTime = 0
 
     rebirthReset()
     gameData.active_challenge = ""
@@ -1020,8 +1031,11 @@ function rebirthThree() {
 	gameData.essence += getEssenceGain()
     gameData.evil = 0
 
-    if (gameData.stats.fastest3 == null || gameData.realtime < gameData.stats.fastest3)
-        gameData.stats.fastest3 = gameData.realtime
+    if (gameData.stats.fastest3 == null || gameData.rebirthThreeTime < gameData.stats.fastest3)
+        gameData.stats.fastest3 = gameData.rebirthThreeTime
+    gameData.rebirthOneTime = 0
+    gameData.rebirthTwoTime = 0
+    gameData.rebirthThreeTime = 0
 
 	const recallEffect = gameData.taskData["Cosmic Recollection"].getEffect();
 
@@ -1044,8 +1058,12 @@ function rebirthFour() {
         gameData.challenges[challenge] = 0
     }
 
-    if (gameData.stats.fastest4 == null || gameData.realtime < gameData.stats.fastest4)
-        gameData.stats.fastest4 = gameData.realtime
+    if (gameData.stats.fastest4 == null || gameData.rebirthFourTime < gameData.stats.fastest4)
+        gameData.stats.fastest4 = gameData.rebirthFourTime
+    gameData.rebirthOneTime = 0
+    gameData.rebirthTwoTime = 0
+    gameData.rebirthThreeTime = 0
+    gameData.rebirthFourTime = 0
 
     rebirthReset()
 
@@ -1387,6 +1405,22 @@ function loadGameData() {
             if (gameData.settings.theme == null) {
                 gameData.settings.theme = 1
             }
+
+            if (gameData.rebirthOneTime == null || gameData.rebirthOneTime === 0) {
+                gameData.rebirthOneTime = gameData.realtime
+            }
+
+            if (gameData.rebirthTwoTime == null || gameData.rebirthTwoTime === 0) {
+                gameData.rebirthTwoTime = gameData.realtime
+            }
+
+            if (gameData.rebirthThreeTime == null || gameData.rebirthThreeTime === 0) {
+                gameData.rebirthThreeTime = gameData.realtime
+            }
+
+            if (gameData.rebirthFourTime == null || gameData.rebirthFourTime === 0) {
+                gameData.rebirthFourTime = gameData.realtime
+            }
         }
     } catch (error) {
         console.error(error)
@@ -1429,18 +1463,18 @@ function updateRequirements() {
 
 function updateStats() {
     if (gameData.requirements["Rebirth stats evil"].isCompleted()) {
-        gameData.stats.EvilPerSecond = getEvilGain() / gameData.realtime
+        gameData.stats.EvilPerSecond = getEvilGain() / gameData.rebirthTwoTime
         if (gameData.stats.EvilPerSecond > gameData.stats.maxEvilPerSecond) {
             gameData.stats.maxEvilPerSecond = gameData.stats.EvilPerSecond
-            gameData.stats.maxEvilPerSecondRt = gameData.realtime
+            gameData.stats.maxEvilPerSecondRt = gameData.rebirthTwoTime
         }
     }
 
     if (gameData.requirements["Rebirth stats essence"].isCompleted()) {
-        gameData.stats.EssencePerSecond = getEssenceGain() / gameData.realtime
+        gameData.stats.EssencePerSecond = getEssenceGain() / gameData.rebirthThreeTime
         if (gameData.stats.EssencePerSecond > gameData.stats.maxEssencePerSecond) {
             gameData.stats.maxEssencePerSecond = gameData.stats.EssencePerSecond
-            gameData.stats.maxEssencePerSecondRt = gameData.realtime
+            gameData.stats.maxEssencePerSecondRt = gameData.rebirthThreeTime
         }
     }
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -616,6 +616,11 @@ function renderSettings() {
     document.getElementById("rebirthThreeCountDisplay").textContent = gameData.rebirthThreeCount
     document.getElementById("rebirthFourCountDisplay").textContent = gameData.rebirthFourCount
 
+    document.getElementById("rebirthOneTimeDisplay").textContent = formatTime(gameData.rebirthOneTime, true)
+    document.getElementById("rebirthTwoTimeDisplay").textContent = formatTime(gameData.rebirthTwoTime, true)
+    document.getElementById("rebirthThreeTimeDisplay").textContent = formatTime(gameData.rebirthThreeTime, true)
+    document.getElementById("rebirthFourTimeDisplay").textContent = formatTime(gameData.rebirthFourTime, true)
+
     document.getElementById("rebirthOneFastestDisplay").textContent = formatTime(gameData.stats.fastest1, true)
     document.getElementById("rebirthTwoFastestDisplay").textContent = formatTime(gameData.stats.fastest2, true)
     document.getElementById("rebirthThreeFastestDisplay").textContent = formatTime(gameData.stats.fastest3, true)


### PR DESCRIPTION
Properly keep track of each prestige layer's reset time separately and make sure that e.g. embracing evil does not reset time since last transcension.

Entering/exiting challenges effectively does an evil reset, so reset the timers as if an evil reset was performed.
The evil/s and essence/s displays now use the respective reset times instead of `gameData.realtime`.

This is cosmetic only for now, but one way this could be useful is if Faint Hope was not reset whenever the player embraced evil (e.g. whilst pushing challenges).