### PR TITLE
Show the total amount of online time played on a save

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,8 +649,8 @@
 										<div id="statsPage" style="flex: 1; margin-left: 0.5em;">
 											<div>
 												<ul>
-													<li>You started playing the game on <span id="startDateDisplay"></span>.</li>
-													<li>You have played for <span id="playedDaysDisplay"></span> days (real time).</li>
+													<li>You started playing the game on <span id="startDateDisplay"></span>, <span id="playedDaysDisplay"></span> days ago.</li>
+													<li>You have played for <span id="playedRealTimeDisplay"></span> (real time).</li>
 													<li>Your existance has spanned <span id="playedGameTimeDisplay"></span> days (game time).</li>
 												</ul>
 											</div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -588,6 +588,7 @@ function renderSettings() {
 
     const currentDate = new Date()
     document.getElementById("playedDaysDisplay").textContent = format((currentDate.getTime() - date.getTime()) / (1000 * 3600 * 24), 2)
+    document.getElementById("playedRealTimeDisplay").textContent = formatTime(gameData.realtimeRun)
 
     document.getElementById("playedGameTimeDisplay").textContent = format(gameData.totalDays, 2)
 


### PR DESCRIPTION
There was an unused variable in the game data called "realtimeRun" which was incremented endlessly and (after the Dark Matter update) never reset, effectively making it a counter for the total online time played since the start of the game.

Display the variable in the stats as such and shift the "X days ago" to the end of the "date of game start" line.

This allows players to see effectively the true total amount of real time spent in the game, potentially allowing for some sort of full-game "speedrun".