### PR TITLE
Fix the width of tooltips

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -223,7 +223,7 @@ button:focus {
     z-index: 1;
     top: 0;
     left: 102%;
-    width: 25vw;
+    width: 32em;
 
     opacity: 0;
     transition: opacity 0.5s;


### PR DESCRIPTION
A recent change resulted in tooltips taking 25% of the width of the display, regardless of font size, causing overflow to the right at smaller font sizes. This has been changed; the tooltips now fit within the column and their width is dependent on the font size, which helps to avoid overflow.