### PR TITLE
Add requirements for milestone categories

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1610,6 +1610,8 @@ gameData.requirements = {
     "Dark Magic": new EvilRequirement([removeSpaces(".Dark Magic")], [{requirement: 1}]),
 	"Almightiness": new EssenceRequirement([".Almightiness"], [{requirement: 1}]),
 	"Darkness": new DarkMatterRequirement([".Darkness"], [{requirement: 1}]),
+    "Heroic Milestones": new EssenceRequirement([removeSpaces(".Heroic Milestones")], [{requirement: 400000}]),
+    "Dark Milestones": new EssenceRequirement([removeSpaces(".Dark Milestones")], [{requirement: 5e10}]),
 
     // Rebirth items
     "Rebirth tab": new AgeRequirement(["#rebirthTabButton"], [{requirement: 25}]),


### PR DESCRIPTION
The "Heroic milestones" and "Dark milestones" categories used to be visible as soon as milestones were unlocked, despite them being far off at that point in progression. Hide these categories until the last milestone in the previous category is unlocked.