### PR TITLE
Fix bullet point markers in the 2.2.9 changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,10 @@
 version 2.2.9 / 06.02.2023
-- Buff to Gotta be fast
-- Rebalance a few milestones
-- Improve endgame challenge rewards
-- 2 more endgame shop items
-- Bug fixes
-- Improved statistics
+* Buff to Gotta be fast
+* Rebalance a few milestones
+* Improve endgame challenge rewards
+* 2 more endgame shop items
+* Bug fixes
+* Improved statistics
 
 version 2.2.8 / 09.01.2023
 * 6 new milestones


### PR DESCRIPTION
Previous changelog entries used asterisks to denote list items, but the new entry used hyphens. Both are acceptable in Markdown, but this change makes it consistent in plaintext.