### PR TITLE
Remove invalid active shop items on load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1427,6 +1427,9 @@ function loadGameData() {
             if (gameData.rebirthFourTime == null || gameData.rebirthFourTime === 0) {
                 gameData.rebirthFourTime = gameData.realtime
             }
+
+            // Remove invalid active misc items
+            gameData.currentMisc = gameData.currentMisc.filter((element) => element instanceof Item)
         }
     } catch (error) {
         console.error(error)


### PR DESCRIPTION
Shop items that are currently active can become invalid on renames; this could cause a crash on load. Remove them from the list to prevent such crashes.