### PR TITLE
Weaken Life Coach effect formula beyond level 30

### DIFF
--- a/js/dark_matter.js
+++ b/js/dark_matter.js
@@ -73,6 +73,8 @@ function getAGiftFromGodEssenceGain() {
 }
 
 function getLifeCoachIncomeGain() {
+    if (gameData.dark_matter_shop.life_coach > 30)
+        return 1e30 * Math.pow(2, gameData.dark_matter_shop.life_coach - 30)
     return Math.pow(10, gameData.dark_matter_shop.life_coach)
 }
 


### PR DESCRIPTION
If Life Coach were to retain its original formula, then if the Dark Orb cap was somehow raised (or Dark Orb upgrade costs reduced), that would make the upgrade very OP beyond late game.

By changing the formula beyond level 30, the effect of Life Coach at level 60 (cost 1e600 Dark Orbs) is reduced from x1e60 to x1e39, which results in more manageable bank balance.

Note: as the maximum level of Life Coach that can be bought for less than 1.80e308 Dark Orbs is 30, this won't actually take effect until the Dark Orb cap is raised.