### PR TITLE
Don't reset Faint Hope time until transcension

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -598,11 +598,11 @@ function setCustomEffects() {
     faintHope.getEffect = function () {
         var mult = 1
         if (gameData.requirements["Faint Hope"].isCompleted()) {
-            let kickin = 1.1754 - 0.082 * Math.log(gameData.realtime)
+            let kickin = 1.1754 - 0.082 * Math.log(gameData.rebirthThreeTime)
             if (kickin < 0.15)
                 kickin = 0.15
 
-            mult = 1 + (gameData.realtime / (7750 * kickin)) * (Math.log(getUnpausedGameSpeed()) / Math.log(2))
+            mult = 1 + (gameData.rebirthThreeTime / (7750 * kickin)) * (Math.log(getUnpausedGameSpeed()) / Math.log(2))
             mult = softcap(mult, 200)
         }
 


### PR DESCRIPTION
Faint Hope is a milestone unlocked with Essence, it multiplies Essence gain over time, and Essence is gained by transcending, so it makes sense for Faint Hope to not reset until transcension.

This allows a player to push challenges and build up Faint Hope multiplier at the same time.

For example, a player could transcend, spend an hour in each of the 5 challenges, spend by an hour outside of challenges, and get a similar buff from Faint Hope as a player that spent 6 consecutive hours outside of challenges since last transcension.