### PR TITLE
Replace BigInts with Logarithms

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -36,17 +36,16 @@ class Task {
     }
 
     getMaxXpLog() {
-        const maxXp = this.getMaxXp() == Infinity ? 305 : Math.log10(this.getMaxXp());
+        let maxXp = (this.isHero ? this.baseData.heroxp : 0) + Math.log10(this.baseData.maxXp*(this.level + 1))
+        maxXp += (this.isHero ? Math.log10(1.08) : Math.log10(1.01)) * this.level
 
         if (maxXp < 305)
             return maxXp
 
-        // The scaling on this is real weird, but you've probably already balanced around it.
-        // The level cost and scaling jumps up at 305, then the cost drops a bit and the scaling plummets a bit later.
-        // Heroic and normal levels scale identically after the drop
-
-        // If you are willing to rebalance, the initial scaling extended would be: 
-        //  (this.isHero ? this.baseData.heroxp : 0) + (this.isHero ? 1.08 : 1.01) * this.level + Math.log10(this.baseData.maxXp*(this.level + 1))
+        //Odd bit of balance, but I'm maintaining the original.
+        //This reduces the scaling a Lot at some point, and treats unheroic as heroic after that point
+        if(maxXp>308.254715) // ~Infinity
+            maxXp = 305;
 
         return maxXp + Math.log10(2) * (this.level/120+this.baseData.heroxp/9)
     }

--- a/js/classes.js
+++ b/js/classes.js
@@ -89,12 +89,14 @@ class Task {
         if (this.isFinished) {
             this.xpLog = addLogs(this.xpLog, applySpeedOnLog(this.getXpGainLog()))
 
-            let curCost = -Infinity
-            for (let nextCost=this.getMaxXpLog(), iterations = 0;nextCost <= this.xpLog && iterations < 2500; nextCost=addLogs(curCost, this.getMaxXpLog()),iterations++) {
+            let excess = this.xpLog
+            let nextCost=this.getMaxXpLog()
+            for (let iterations = 0;excess >= nextCost && iterations < 2500; iterations++) {
                 this.level += 1
-                curCost = nextCost
+                excess = subLogs(excess, nextCost)
+                nextCost=this.getMaxXpLog()
             }
-            this.xpLog = subLogs(this.xpLog, curCost)
+            this.xpLog = excess
         } else {
             this.xp += applySpeed(this.getXpGain())
 

--- a/js/main.js
+++ b/js/main.js
@@ -692,10 +692,8 @@ function applySpeed(value) {
     return value * getGameSpeed() / updateSpeed
 }
 
-function applySpeedOnBigInt(value) {
-    if (value == 0n)
-        return 0n
-    return value * BigInt(Math.floor(getGameSpeed())) / BigInt(Math.floor(updateSpeed))
+function applySpeedOnLog(value) {
+    return value + Math.log10(getGameSpeed()/updateSpeed)
 }
 
 function getEvilGain() {
@@ -1140,6 +1138,7 @@ function rebirthReset(set_tab_to_jobs = true) {
         if (task.level > task.maxLevel) task.maxLevel = task.level
         task.level = 0
         task.xp = 0
+        task.xpLog = -Infinity
         task.isHero = false
         task.isFinished =false
     }
@@ -1259,6 +1258,14 @@ function makeHeroes() {
 function assignMethods() {
     for (const key in gameData.taskData) {
         let task = gameData.taskData[key]
+
+        if (!('xpLog' in task) && ('xpBigInt' in task)){
+            if (typeof task.xpBigInt === "string" && task.xpBigInt.includes("e"))
+                task.xpBigInt = exponentialToRawNumberString(task.xpBigInt)
+
+            task.xpLog = task.xpBigInt.length + Math.log10("0." + task.xpBigInt.substring(0, 15)) // This line from StackOverflow
+        }
+
         if (task.baseData.income) {
             task.baseData = jobBaseData[task.name]
             task = Object.assign(new Job(jobBaseData[task.name]), task)
@@ -1267,12 +1274,6 @@ function assignMethods() {
             task.baseData = skillBaseData[task.name]
             task = Object.assign(new Skill(skillBaseData[task.name]), task)
         }
-
-        // There are two cases. The number is stored as a large number or in the scientific notation.
-        if (typeof task.xpBigInt === "string" && task.xpBigInt.includes("e"))
-            task.xpBigInt = BigInt(exponentialToRawNumberString(task.xpBigInt))
-        else
-            task.xpBigInt = BigInt(task.xpBigInt)
 
         gameData.taskData[key] = task
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -195,23 +195,9 @@ function removeStrangeCharacters(string) {
     return string.replace(/'/g, "")
 }
 
-function bigIntToExponential(value) {
-    if(typeof value !== 'bigint') throw new Error("Argument must be a bigint, but a " + (typeof value) + " was supplied.");
-
-    const isNegative = value < 0;
-    if (isNegative) value = -value; // Using the absolute value for the digits.
-
-    const str = value.toString();
-
-    const exp = str.length - 1;
-    if (exp == 0) return (isNegative ? "-" : '') + str + "e0";
-
-    const mantissaDigits = str.replace(/(0+)$/, ''); // Remove any mathematically insignificant zeroes.
-
-    // Use the single first digit for the integral part of the mantissa
-    const mantissa = mantissaDigits.charAt(0);
-
-    return (isNegative ? "-" : '') + mantissa + "e" + exp.toString();
+function logToExponential(value) {
+    const exp = Math.floor(value);
+    return Math.floor(10**(value-exp)) + "e" + exp;
 }
 
 function exponentialToRawNumberString(value) {
@@ -239,4 +225,10 @@ function getFormattedChallengeTaskGoal(taskName, level) {
         return taskName + " lvl " + formatLevel(level)
     else
         return "Great " + taskName + " lvl " + formatLevel(Math.ceil(level / 1000))
+}
+function addLogs(a,b){
+    return math.max(a,b) + Math.log10(1+.1**Math.abs(a-b))
+}
+function subLogs(a,b){
+    return a+Math.log10(1-.1**(a-b))
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -227,7 +227,7 @@ function getFormattedChallengeTaskGoal(taskName, level) {
         return "Great " + taskName + " lvl " + formatLevel(Math.ceil(level / 1000))
 }
 function addLogs(a,b){
-    return math.max(a,b) + Math.log10(1+.1**Math.abs(a-b))
+    return Math.max(a,b) + Math.log10(1+.1**Math.abs(a-b))
 }
 function subLogs(a,b){
     return a+Math.log10(1-.1**(a-b))


### PR DESCRIPTION
This gives a decent speedup post e305 xp, and increases the iterations in `increaseXp`.

This does cause a small slowdown (~10%) in level gains past e305 xp, due to the removal of some aggresive rounding in the players favor while converting to BigInt.

This also fixes an issue that the BigInt xp is not reset on rebirth, which I couldn't notify you of elsewhere because the project doesn't have an Issues tab, and I'm not making a pull request for a single line of code