### PR TITLE
Fix hypercube production displays while game is paused

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -323,6 +323,14 @@ function applySpeed(value) {
     return value * getGameSpeed() / updateSpeed
 }
 
+function applyUnpausedSpeed(value) {
+    if (value == 0)
+        return 0
+    if (value == Infinity)
+        return Infinity
+    return value * getUnpausedGameSpeed() / updateSpeed
+}
+
 function applySpeedOnBigInt(value) {
     if (value == 0n)
         return 0n

--- a/js/metaverse.js
+++ b/js/metaverse.js
@@ -13,7 +13,7 @@ function getNextPowerOfNumber(number, add_power = 0) {
 }
 
 function getTimeTillNextHypercubePower(add_power = 0) {
-    return (getNextPowerOfNumber(gameData.hypercubes, add_power) - gameData.hypercubes) / (applySpeed(getHypercubeGeneration()) * updateSpeed)
+    return (getNextPowerOfNumber(gameData.hypercubes, add_power) - gameData.hypercubes) / (applyUnpausedSpeed(getHypercubeGeneration()) * updateSpeed)
 }
 
 function getBoostTimeSeconds() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -481,7 +481,7 @@ function renderMetaverse() {
     document.getElementById("boostDurationCost").textContent = format(boostDurationCost())
     document.getElementById("boostDurationBuyButton").disabled = !canBuyBoostDuration()
 
-    document.getElementById("hypercubeGain").textContent = format(getHypercubeGeneration() * getGameSpeed(),2)
+    document.getElementById("hypercubeGain").textContent = format(applyUnpausedSpeed(getHypercubeGeneration()),2)
     document.getElementById("hypercubeGainCost").textContent = format(hypercubeGainCost())
     document.getElementById("hypercubeGainBuyButton").disabled = !canBuyHypercubeGain()
 


### PR DESCRIPTION
Previously, pausing the game would zero out hypercube production displays and make hypercube time estimates become infinite, which may not be wanted by some players.

Now, hypercube production and time estimates remain at a sane value and pause while the game is paused.