### PR TITLE
Show next hypercube cap as Infinity on perk unlock

### DIFF
--- a/js/metaverse.js
+++ b/js/metaverse.js
@@ -270,7 +270,7 @@ function getUnspentPerksDarkmatterGainBuff() {
 }
 
 function getHypercubeCap(next = 0) {
-    if (getTotalPerkPoints() >= 1)
+    if (getTotalPerkPoints() >= 1 || (next > 0 && getMetaversePerkPointsGain() > 0))
         return Infinity
 
     return 1e7 * Math.pow(10, (gameData.rebirthFiveCount + next) * 3)


### PR DESCRIPTION
Currently, when you would unlock Metaverse Perks on your next Metaverse, the Hypercube Cap is displayed as a finite value less than e308, which is incorrect as the true cap jumps to that value on the metaverse reset that unlocks metaverse perks.