### PR TITLE
Clarify the lifespan debuff in the challenge 5 description post-Metaverse

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
 									</div>
 									<div id="legendsNeverDieChallenge" style="padding-top:2em">
 										<div class="text-caption challenge-title">5. Legends never die</div>
-										<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, happiness does nothing and Dark Magic XP effect is always 1x</div>
+										<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, happiness does nothing and Dark Magic XP effect is always 1x. <span id="challenge5MetaverseLifespanDebuff">The "Lifespan is now Infinity" buff from Metaverse is disabled.</span></div>
 										<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <span id="challengeGoal5">Chairman lvl 1227</span></div>
 										<div id="challengeReward5" class="reward">Reward: Multiplies <span class="color-evil">Evil</span> gain by x<span id="challengeEvilGainBuff">1</span></div>
 										<button id="challengeButton5" class="w3-button button" onclick="enterChallenge('legends_never_die')">Enter challenge</button>

--- a/js/ui.js
+++ b/js/ui.js
@@ -380,6 +380,8 @@ function renderChallenges() {
     document.getElementById("challengeEssenceGainBuff").textContent = format(getChallengeBonus("dance_with_the_devil"), 2)
     document.getElementById("challengeEvilGainBuff").textContent = format(getChallengeBonus("legends_never_die"), 2)
     document.getElementById("challengeDarkMatterGainBuff").textContent = format(getChallengeBonus("the_darkest_time"), 2)
+
+    document.getElementById("challenge5MetaverseLifespanDebuff").hidden = gameData.rebirthFiveCount == 0
 }
 
 function renderCurrentChallengeReward(blockclass) {


### PR DESCRIPTION
After Metaverse, lifespan is infinite except when in challenges 5 or 6 (which ordinally reduces lifespan); however that is not accounted for in the description.

Add text to the challenge 5 description stating the lifespan buff from Metaverse is disabled when in that challenge. This text only shows after the first Metaverse reset.

Note to maintainers: don't merge this if you will merge #78 instead as that PR makes this PR redundant.