### PR TITLE
Don't let challenge 5 disable metaverse immortality

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -938,6 +938,8 @@ function rebirthReset(set_tab_to_jobs = true) {
 }
 
 function getLifespan() {
+    if (gameData.rebirthFiveCount > 0) return Infinity
+
     const immortality = gameData.taskData["Life Essence"]
     const superImmortality = gameData.taskData["Astral Body"]
     const higherDimensions = gameData.taskData["Higher Dimensions"]
@@ -949,8 +951,6 @@ function getLifespan() {
         * cosmicLongevity.getEffect() * higherDimensions.getEffect() * lifeIsValueable * speedSpeedSpeed
 
     if (gameData.active_challenge == "legends_never_die" || gameData.active_challenge == "the_darkest_time") return Math.pow(lifespan, 0.72) + 365 * 25
-
-    if (gameData.rebirthFiveCount > 0) return Infinity
 
     return lifespan
 }


### PR DESCRIPTION
Running challenge 5 post-Metaverse may fail very early on as the game time per tick may exceed starting lifespan, especially if boost is active. Fix this by allowing the metaverse "Lifespan is now Infinity" buff to apply even in challenges.

As a bonus, this optimizes the lifespan calculation for players on their second metaverse onwards.

Note to self: close #77 when this is merged as it is redundant.