### PR TITLE
Fix hypercube sacrifice to challenge altar

### DIFF
--- a/js/metaverse.js
+++ b/js/metaverse.js
@@ -136,7 +136,7 @@ function canBuyChallengeAltar() {
 
 function buyChallengeAltar() {
     if (canBuyChallengeAltar()) {
-        gameData.hypercubes -= essenceMultCost()
+        gameData.hypercubes -= challengeAltarCost()
         gameData.metaverse.challenge_altar = 1
     }
 }


### PR DESCRIPTION
Sacrificing hypercubes to stop challenges being reset on collapse deducted the cost for the next level of essence multiplier.

If a player had enough hypercubes to stop challenges being reset, but not enough for the next level of essence multiplier, their hypercube count would become negative when sacrificing to prevent challenges being reset.

This is now fixed; the challenge altar sacrifice now always deducts its fixed sacrifice cost of 1e10, instead of the cost for the next level of essence multiplier.