### PR TITLE
Fix the hypercube per-second display again

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -483,7 +483,7 @@ function renderMetaverse() {
     document.getElementById("boostDurationCost").textContent = format(boostDurationCost())
     document.getElementById("boostDurationBuyButton").disabled = !canBuyBoostDuration()
 
-    document.getElementById("hypercubeGain").textContent = format(applyUnpausedSpeed(getHypercubeGeneration()),2)
+    document.getElementById("hypercubeGain").textContent = format(getHypercubeGeneration() * getUnpausedGameSpeed(),2)
     document.getElementById("hypercubeGainCost").textContent = format(hypercubeGainCost())
     document.getElementById("hypercubeGainBuyButton").disabled = !canBuyHypercubeGain()
 


### PR DESCRIPTION
My last commit touching this code mistakenly removed a factor of updateSpeed (20) from the displayed hypercube production. This is now fixed; the factor is in which should make the displayed value match actual production.

The underlying cause was my brief misunderstanding of what two functions did:
- Suppose a production rate of 5 hypercubes per day and a game speed of 40 days per second.
- The goal is to have the 'hypercubes per second' display say '200 / s'.
- The code previously there would call `applyUnpausedSpeed()` on the result of `getHypercubeGeneration()` (5 in this case). `applyUnpausedSpeed()` would take this 5, multiply it by `getUnpausedGameSpeed()` (40), then divide it by `updateSpeed` (20) to get 10, which is the hypercubes generated per **tick**, not per second.
- The updated code simply takes the product of `getHypercubeGeneration()` and `applyUnpausedSpeed()` (similar to how it was originally). `getHypercubeGeneration()` = 5 per day, `applyUnpausedSpeed()` = 40 days per second, their product = 200 per second.

Regression from #74