### PR TITLE
Add missing "alt" attribute to Discord icon "img" tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -851,7 +851,7 @@
 											<div style="margin-bottom: 8px;">
 												Based on a <a href="https://symb1.github.io/progress_knight_2/" target="_blank">Progress Knight 2.0</a> mod
 												<br>Original game: <a href="https://ihtasham42.github.io/progress-knight/" target="_blank">Progress Knight</a>
-												<br><a href="https://discord.gg/fTRS4pHGka" target="_blank">Join the discord community! <img src="img/discord_icon.png" style="width:3em; height:3em;"></a>
+												<br><a href="https://discord.gg/fTRS4pHGka" target="_blank">Join the discord community! <img src="img/discord_icon.png" alt="Discord icon" style="width:3em; height:3em;"></a>
 												<br><a href="https://github.com/indomit/progress_knight_2" target="_blank">Github page</a>
 											</div>
 										</li>


### PR DESCRIPTION
I just added an "alt" attribute to the Discord icon "img" tag. Rest of the game was unchanged.