### PR TITLE
Fix an inconsistency in the C5 text post-Metaverse

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
 									</div>
 									<div id="legendsNeverDieChallenge" style="padding-top:2em">
 										<div class="text-caption challenge-title">5. Legends never die</div>
-										<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, time warping by ^0.75, happiness does nothing and Dark Magic XP effect is always 1x. <span id="challenge5MetaverseLifespanDebuff">The "Lifespan is now Infinity" buff from Metaverse is disabled.</span></div>
+										<div style="color: gray; padding-bottom: 0.3em">Reduces your lifespan by ^0.72, time warping by ^0.75, happiness does nothing and Dark Magic XP effect is always 1x. <span id="challenge5MetaverseLifespanDebuff">The infinite lifespan buff from Metaverse is disabled.</span></div>
 										<div style="color: gold; padding-bottom: 0.3em">Goal: Reach <span id="challengeGoal5">Chairman lvl 1227</span></div>
 										<div id="challengeReward5" class="reward">Reward: Multiplies <span class="color-evil">Evil</span> gain by x<span id="challengeEvilGainBuff">1</span></div>
 										<button id="challengeButton5" class="w3-button button" onclick="enterChallenge('legends_never_die')">Enter challenge</button>


### PR DESCRIPTION
With the changes in 4c5024627e02a128eec75361ba368ca72d5d97b4, the C5 text post-Metaverse had an inconsistency, where the "Lifespan is now Infinity" part didn't match the "Lifespan is now infinite" the first line in the text of the Metaverse tab was changed to.

Change "Lifespan is now Infinity" to "infinite lifespan" in the C5 text post-Metaverse to resolve the inconsistency.

If needed, the C5 text post-Metaverse can instead be changed to mention "Lifespan is now infinite" to preserve a literal match.