### PR TITLE
Add a validition check before each of the rebirth functions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -693,6 +693,9 @@ function setEnableKeybinds(enableKeybinds) {
 }
 
 function rebirthOne() {
+    if (!gameData.requirements["Rebirth button 1"].isCompleted())
+        return;
+
     gameData.rebirthOneCount += 1
     if (gameData.stats.fastest1 == null || gameData.rebirthOneTime < gameData.stats.fastest1)
         gameData.stats.fastest1 = gameData.rebirthOneTime
@@ -702,6 +705,9 @@ function rebirthOne() {
 }
 
 function rebirthTwo() {
+    if (!gameData.requirements["Rebirth button 2"].isCompleted())
+        return;
+
     gameData.rebirthTwoCount += 1
     gameData.evil += getEvilGain()
 
@@ -720,6 +726,9 @@ function rebirthTwo() {
 }
 
 function rebirthThree() {
+    if (!gameData.requirements["Rebirth button 3"].isCompleted())
+        return;
+
     gameData.rebirthThreeCount += 1
     gameData.essence += getEssenceGain()
     if (gameData.essence == Infinity)
@@ -745,6 +754,9 @@ function rebirthThree() {
 }
 
 function rebirthFour() {
+    if (!gameData.requirements["Rebirth button 4"].isCompleted())
+        return;
+
     gameData.rebirthFourCount += 1
     gameData.essence = 0
     gameData.evil = 0
@@ -775,6 +787,9 @@ function rebirthFour() {
 }
 
 function rebirthFive() {
+    if (!gameData.requirements["Rebirth button 5"].isCompleted())
+        return;
+
     gameData.rebirthFiveCount += 1
     gameData.perks_points += getMetaversePerkPointsGain()
     gameData.essence = 0

--- a/js/ui.js
+++ b/js/ui.js
@@ -1319,28 +1319,23 @@ window.addEventListener('keydown', function (e) {
             return
 
         if (e.key == "q") {
-            if (gameData.requirements["Rebirth button 1"].isCompleted())
-                rebirthOne()
+            rebirthOne()
         }
 
         if (e.key == "e") {
-            if (gameData.requirements["Rebirth button 2"].isCompleted())
-                rebirthTwo()
+            rebirthTwo()
         }
 
         if (e.key == "t") {
-            if (gameData.requirements["Rebirth button 3"].isCompleted())
-                rebirthThree()
+            rebirthThree()
         }
 
         if (e.key == "u") {
-            if (gameData.requirements["Rebirth button 4"].isCompleted())
-                rebirthFour()
+            rebirthFour()
         }
 
         if (e.key == "g") {
-            if (gameData.requirements["Rebirth button 5"].isCompleted())
-                rebirthFive()
+            rebirthFive()
         }
 
         switch (e.key) {


### PR DESCRIPTION
The rebirth functions don't check to see if you meet the requirements for the respective rebirth before executing, this adds those checks.

If you are writing automation scripts for the game, without the check you can do early rebirths by firing the functions as exist now.  The script author needs to check to see if conditions are met otherwise can "cheat" the run with early rebirths.
