### PR TITLE
Apply padding to the "Next effect" text only

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -78,7 +78,7 @@ td {
     color: rgb(245, 119, 13);
 }
 
-.effect {
+.next-effect {
     margin-bottom: 0.8rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
 									<span class="darkMatter color-dark-matter"></span>
 									<span class="hypercube color-hypercubes"></span>
 								</div>
-								<div class="effect">
+								<div class="effect next-effect">
 									<span class="w3-text-gray">Next effect:</span> <span class="effectValue"></span>
 								</div>
 							</td>


### PR DESCRIPTION
The way 4c5024627e added padding to the next effect text caused the income and effect displays in the hero and skill tables to become misaligned, as padding was added to not only the next effect text but also all other effect displays.

This is fixed by creating a new CSS class for just the next effect text and applying the padding there and there only.