### PR TITLE
Shorten exported saves by removing unnecessary data

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -171,6 +171,23 @@ class Job extends Task {
         this.incomeMultipliers = []
     }
 
+    toJSON() {
+        return {
+            baseData: {
+                // This is the minimum information necessary for a task to load as a hero.
+                income: 1
+            },
+            name: this.name,
+            level: this.level,
+            maxLevel: this.maxLevel,
+            xp: this.xp,
+            xpBigInt: bigIntToExponential(this.xpBigInt),
+            isHero: this.isHero,
+            isFinished: this.isFinished,
+            unlocked: this.unlocked
+        }
+    }
+
     getLevelMultiplier() {
         return 1 + Math.log10(this.level + 1)
     }
@@ -190,6 +207,22 @@ class Skill extends Task {
         super(baseData)
     }
 
+    toJSON() {
+        return {
+            baseData: {
+                // Skills do not need any information in the saved baseData object, but it must still exist for loading to work.
+            },
+            name: this.name,
+            level: this.level,
+            maxLevel: this.maxLevel,
+            xp: this.xp,
+            xpBigInt: bigIntToExponential(this.xpBigInt),
+            isHero: this.isHero,
+            isFinished: this.isFinished,
+            unlocked: this.unlocked
+        }
+    }
+
     getEffect() {
         var effect = 1 + this.baseData.effect * (this.isHero ? 1000 * this.level + 8000 : this.level)
         return effect
@@ -207,6 +240,14 @@ class Item {
         this.expenseMultipliers = []
         this.isHero = false
         this.unlocked = false
+    }
+
+    toJSON() {
+        return {
+            name: this.name,
+            isHero: this.isHero,
+            unlocked: this.unlocked
+        }
     }
 
     getEffect() {
@@ -274,6 +315,13 @@ class Requirement {
         this.elements = []
         this.requirements = requirements
         this.completed = false
+    }
+
+    toJSON() {
+        return {
+            completed: this.completed,
+            type: this.type
+        }
     }
 
     queryElements() {


### PR DESCRIPTION
In my tests, a save file that was 107 kB before this modification now exports as a 45.2-kB save, with no loss of functionality on the front end.

Adding new properties to `baseData` in the hero, skill, and item definitions will now no longer directly impact save file sizes.

`baseData` is still kept in the exported saves for compatibility, until a save version system is implemented.

Please test this PR with your saves and report back if there are problems.

### Test details
In the following tests, I used a (synthetically created) save file, attached here: [test save.txt](https://github.com/indomit/progress_knight_2/files/14736300/test.save.txt)

Importing the test save file, then exporting the game without any modifications resulted in a save file of 107 kB.

Removing all unnecessary properties of `baseData` in heroes and skills from the exported data reduced the exported file size to 98.6 kB.

Removing unnecessary `querySelectors`, `elements`, and `requirements` properties from all requirements objects in the exported data reduced the exported file size to 63.3 kB.

Finally, removing all uncessary properties in items from the exported data reduced the exported file size to 45.2 kB.