### PR TITLE
fix changeTab infinite loop with targetTab = 0 and direction = -1

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1415,7 +1415,7 @@ function changeTab(direction){
              currentTab = i*1
     }
     let targetTab = currentTab + direction
-    if (targetTab < 0) {
+    if (targetTab <= 0) {
         setTab(Tab.SETTINGS)
         return
     }


### PR DESCRIPTION
There's a UI bug where if you use the left arrow hot key from the first tab (Hero), the game goes into an infinite loop and stalls.

It happens in the `changeTab` function when `targetTab = 0` and `direction = -1`.