### PR TITLE
A bug in the upper tab fixed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+version 2.5.1 / 18.05.2025
+* Fix changeTab infinite loop when the player pressed the left arrow from the first tab ('Hero') to the last tab directly. Now it must works fine.
+
 version 2.5.0 / 01.08.2024
 * Improved display on mobile devices
 * Added offline progress (up to 1 hour)

--- a/index.html
+++ b/index.html
@@ -928,7 +928,7 @@
 												</div>
 											</li>
 										</ul>
-										<span id="version" style="font-size:smaller; float:right" class="w3-text-gray">Version: 2.5.0</span>
+										<span id="version" style="font-size:smaller; float:right" class="w3-text-gray">Version: 2.5.1/span>
 									</div>
 								</div>
 								<div id="statsTab" class="tabSettings">

--- a/js/ui.js
+++ b/js/ui.js
@@ -1415,7 +1415,7 @@ function changeTab(direction){
              currentTab = i*1
     }
     let targetTab = currentTab + direction
-    if (targetTab < 0) {
+    if (targetTab <= 0) {
         setTab(Tab.SETTINGS)
         return
     }


### PR DESCRIPTION
Now we can press 'left_arrow' in first tab without the game stucks in infinite loop.